### PR TITLE
fix: Windows console crash on emoji/CJK print output

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,6 +21,14 @@ multiprocessing.freeze_support()
 # 确保模块路径正确
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+# Fix Windows console encoding: default cp1252 cannot render emoji/CJK characters,
+# causing UnicodeEncodeError crashes on print(). Reconfigure to UTF-8 with replacement
+# fallback so all log output survives regardless of the console codepage.
+if sys.platform == "win32":
+    import io
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
+
 from PySide6.QtWidgets import QApplication
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon


### PR DESCRIPTION
## Summary

Running SuperPicky from source on Windows crashes immediately with a `UnicodeEncodeError` because the default cp1252 console encoding cannot render emoji and CJK characters used in log output.

The crash occurs on startup in `tools/i18n.py` when printing the language pack load status:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\u2705' in position 0: character maps to <undefined>
```

## Fix

Reconfigure `sys.stdout` and `sys.stderr` to UTF-8 with a `replace` error handler early in `main.py`, before any imports that produce print output. This is guarded with `sys.platform == "win32"` so it only applies on Windows.

## Test plan

- [x] Verified the app launches from source on Windows 11 without `PYTHONIOENCODING=utf-8`
- [ ] Verify no regression on macOS (fix is Windows-only, no code path change on macOS)