### PR TITLE
feat: right-click context menu on ResultCard to copy bird name

### DIFF
--- a/ui/birdid_dock.py
+++ b/ui/birdid_dock.py
@@ -305,6 +305,49 @@ class ResultCard(QFrame):
         self.clicked.emit(self.rank)
         super().mousePressEvent(event)
 
+    def contextMenuEvent(self, event):
+        """右键菜单：复制鸟名"""
+        from PySide6.QtWidgets import QMenu
+        is_en = self.i18n.current_lang.startswith('en')
+        name = self.en_name if is_en else self.cn_name
+
+        menu = QMenu(self)
+        menu.setStyleSheet(f"""
+            QMenu {{
+                background-color: {COLORS['bg_card']};
+                border: 1px solid {COLORS['border']};
+                border-radius: 6px;
+                padding: 4px;
+                color: {COLORS['text_primary']};
+                font-size: 13px;
+            }}
+            QMenu::item {{
+                padding: 6px 16px;
+                border-radius: 4px;
+            }}
+            QMenu::item:selected {{
+                background-color: {COLORS['accent']};
+                color: {COLORS['bg_void']};
+            }}
+            QMenu::separator {{
+                height: 1px;
+                background: {COLORS['border_subtle']};
+                margin: 4px 8px;
+            }}
+        """)
+
+        copy_label = f'Copy "{name}"' if is_en else f'复制 "{name}"'
+        menu.addAction(copy_label, lambda: QApplication.clipboard().setText(name))
+
+        menu.addSeparator()
+
+        full = f"{self.cn_name} / {self.en_name} ({self.confidence:.0f}%)"
+        full_label = "Copy full info" if is_en else "复制完整信息"
+        menu.addAction(full_label, lambda: QApplication.clipboard().setText(full))
+
+        menu.exec(event.globalPos())
+
+
 
 class BirdIDDockWidget(QDockWidget):
     """鸟类识别停靠面板 - 深色主题"""


### PR DESCRIPTION
## Summary

Adds a right-click context menu on identification result cards (`ResultCard`) in the BirdID dock panel.

## Changes

- **File**: `ui/birdid_dock.py`
- **Class**: `ResultCard`
- **New method**: `contextMenuEvent()`

## Behavior

When the user right-clicks on any identification result card:

- **Chinese UI**: shows `复制 "蓝眉林鸲"` (copies Chinese name)
- **English UI**: shows `Copy "Red-flanked Bluetail"` (copies English name)
- A separator + **"复制完整信息" / "Copy full info"** option copies the combined string: `蓝眉林鸲 / Red-flanked Bluetail (94%)`

The menu is styled to match the dark theme using the existing `COLORS` system.

## Why

Users frequently need to copy bird names after identification (e.g., for notes, Lightroom captions, searches). This was a quick win with zero impact on existing functionality.