### PR TITLE
Reapply interrupted-job resume tracking on dev

### DIFF
--- a/core/photo_processor.py
+++ b/core/photo_processor.py
@@ -17,6 +17,7 @@ import sys
 import time
 import json
 import math
+import hashlib
 import subprocess
 import shutil
 import threading
@@ -174,6 +175,10 @@ class PhotoProcessor:
         self.burst_map = {}  # V4.0.4: Track burst group IDs: {filepath: group_id}, 0 = not a burst
         # SQLite 报告数据库（替代 CSV 缓存）
         self.report_db = None  # 在 _run_ai_detection 中初始化
+        self._session_id = None
+        self._resume_snapshot = {}
+        self._resume_active = False
+        self._settings_hash = None
         
         # 性能日志开关（支持 settings 和环境变量）
         env_perf = os.getenv("SUPERPICKY_PERF_LOG", "").strip().lower() in {"1", "true", "yes", "on"}
@@ -467,7 +472,8 @@ class PhotoProcessor:
     def process(
         self,
         organize_files: bool = True,
-        cleanup_temp: bool = True
+        cleanup_temp: bool = True,
+        resume: bool = False
     ) -> ProcessingResult:
         """
         主处理流程
@@ -481,8 +487,14 @@ class PhotoProcessor:
         """
         start_time = time.time()
         self.stats['start_time'] = start_time
+        if self.report_db is None:
+            self.report_db = ReportDB(self.dir_path)
+        self._settings_hash = self._build_settings_hash(organize_files, cleanup_temp)
+        self._resume_snapshot = self.report_db.get_resume_snapshot()
+        self._prepare_session(resume=resume)
         
         # 阶段1: 文件扫描
+        self.report_db.set_job_stage('scan')
         raw_dict, jpg_dict, files_tbr = self._scan_files()
         
         # 阶段1.5: V4.0.4 早期连拍检测（只基于时间戳）
@@ -495,13 +507,19 @@ class PhotoProcessor:
             self._convert_raws(raw_files_to_convert, files_tbr)
         
         # 阶段3: AI检测与评分
+        self.report_db.set_job_stage('analyze')
+        files_tbr = self._filter_files_for_resume(files_tbr)
         self._process_images(files_tbr, raw_dict)
         
         # 阶段4: 精选旗标计算（metadata_write_mode=none 时跳过）
+        self.report_db.set_job_stage('picked')
+        self._restore_runtime_state()
         if get_advanced_config().get_metadata_write_mode() != "none":
             self._calculate_picked_flags()
         
         # 阶段5: 文件组织
+        self.report_db.set_job_stage('organize')
+        self._restore_runtime_state()
         if organize_files:
             self._move_files_to_rating_folders(raw_dict)
         
@@ -512,6 +530,7 @@ class PhotoProcessor:
             self.stats['burst_moved'] = burst_stats.get('moved', 0)
         
         # 阶段7: 临时文件处理
+        self.report_db.set_job_stage('cleanup')
         if cleanup_temp:
             self._cleanup_temp_files(files_tbr, raw_dict)
         else:
@@ -529,6 +548,8 @@ class PhotoProcessor:
             self.stats['total_time'] / self.stats['total']
             if self.stats['total'] > 0 else 0
         )
+        self.report_db.set_job_stage('completed')
+        self.report_db.finish_session('completed')
         
         # 关闭数据库连接（在所有阶段完成后）
         if hasattr(self, 'report_db') and self.report_db:
@@ -541,6 +562,69 @@ class PhotoProcessor:
             total_time=self.stats['total_time'],
             avg_time=self.stats['avg_time']
         )
+
+    def _build_settings_hash(self, organize_files: bool, cleanup_temp: bool) -> str:
+        payload = {
+            'dir_path': os.path.abspath(self.dir_path),
+            'settings': self.settings.__dict__.copy(),
+            'organize_files': bool(organize_files),
+            'cleanup_temp': bool(cleanup_temp),
+        }
+        encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False).encode('utf-8')
+        return hashlib.sha256(encoded).hexdigest()
+
+    def _prepare_session(self, resume: bool) -> None:
+        snapshot = self._resume_snapshot or {}
+        if snapshot.get('can_resume'):
+            existing_hash = snapshot.get('job_settings_hash') or ''
+            if existing_hash and existing_hash != self._settings_hash:
+                raise RuntimeError("发现未完成任务，但当前参数与上次处理不一致。请先重置目录后重跑。")
+            if not resume:
+                self._log("⏯️ 检测到未完成任务，自动切换为继续上次处理。", "warning")
+                resume = True
+
+        session = self.report_db.begin_session(self._settings_hash, resume=bool(resume and snapshot.get('can_resume')))
+        self._session_id = session['session_id']
+        self._resume_active = bool(resume and snapshot.get('can_resume'))
+
+    def _filter_files_for_resume(self, files_tbr: List[str]) -> List[str]:
+        if not self.report_db:
+            return files_tbr
+        incomplete = set(self.report_db.get_incomplete_photo_prefixes())
+        if not incomplete:
+            return files_tbr
+        filtered = [filename for filename in files_tbr if os.path.splitext(os.path.basename(filename))[0] in incomplete]
+        if self._resume_active:
+            skipped = len(files_tbr) - len(filtered)
+            self._log(f"⏯️ Resume active: skipping {skipped} completed photos")
+        return filtered
+
+    def _restore_runtime_state(self):
+        if not self.report_db:
+            return
+        summary = self.report_db.load_processing_summary()
+        self.file_ratings = summary.get('file_ratings', {})
+        self.star_3_photos = summary.get('star_3_photos', [])
+        for photo in self.star_3_photos:
+            file_ref = photo.get('file')
+            if file_ref and not os.path.isabs(file_ref):
+                photo['file'] = os.path.join(self.dir_path, file_ref)
+        self.file_bird_species = summary.get('bird_species', {})
+        self.stats['bird_species'] = list(summary.get('bird_species', {}).values())
+        self._recalculate_stats_from_db()
+
+    def _recalculate_stats_from_db(self):
+        if not self.report_db:
+            return
+        stats = self.report_db.get_statistics()
+        by_rating = stats.get('by_rating', {})
+        self.stats['total'] = stats.get('total', 0)
+        self.stats['no_bird'] = by_rating.get(-1, 0)
+        self.stats['star_0'] = by_rating.get(0, 0)
+        self.stats['star_1'] = by_rating.get(1, 0)
+        self.stats['star_2'] = by_rating.get(2, 0)
+        self.stats['star_3'] = by_rating.get(3, 0)
+        self.stats['flying'] = stats.get('flying', 0)
     
     def _scan_files(self) -> Tuple[dict, dict, list]:
         """扫描目录文件"""
@@ -884,7 +968,8 @@ class PhotoProcessor:
         model = load_yolo_model()
         
         # 初始化 SQLite 报告数据库
-        self.report_db = ReportDB(self.dir_path)
+        if self.report_db is None:
+            self.report_db = ReportDB(self.dir_path)
         
         # 获取关键点检测模型
         keypoint_detector = get_keypoint_detector()
@@ -912,6 +997,7 @@ class PhotoProcessor:
         
         exiftool_mgr = get_exiftool_manager()
         metadata_batch: List[Dict] = []
+        metadata_batch_prefixes: List[str] = []
         metadata_batch_size = 64
         env_exif_batch = os.getenv("SUPERPICKY_EXIF_BATCH_SIZE", "").strip()
         if env_exif_batch.isdigit():
@@ -932,13 +1018,19 @@ class PhotoProcessor:
         if metadata_async_enabled:
             def metadata_writer_worker():
                 while True:
-                    batch = metadata_queue.get()
-                    if batch is None:
+                    batch_item = metadata_queue.get()
+                    if batch_item is None:
                         metadata_queue.task_done()
                         break
+                    if isinstance(batch_item, tuple):
+                        batch, batch_prefixes = batch_item
+                    else:
+                        batch, batch_prefixes = batch_item, []
                     exif_start = time.time()
                     try:
                         exiftool_mgr.batch_set_metadata(batch)
+                        if self.report_db and batch_prefixes:
+                            self.report_db.mark_photos_metadata_done(batch_prefixes, self._session_id or "")
                     except Exception as e:
                         metadata_writer_errors.append(e)
                     finally:
@@ -964,7 +1056,11 @@ class PhotoProcessor:
             if not metadata_batch:
                 return
             batch = metadata_batch.copy()
+            batch_prefixes = metadata_batch_prefixes.copy()
             metadata_batch.clear()
+            metadata_batch_prefixes.clear()
+            if self.report_db and batch_prefixes:
+                self.report_db.mark_photos_metadata_queued(batch_prefixes, self._session_id or "")
             if metadata_async_enabled and metadata_queue is not None:
                 enqueue_start = time.time()
                 metadata_queue.put(batch)  # 队列满时会背压，避免内存无限增长
@@ -974,6 +1070,8 @@ class PhotoProcessor:
                 return
             exif_start = time.time()
             exiftool_mgr.batch_set_metadata(batch)
+            if self.report_db and batch_prefixes:
+                self.report_db.mark_photos_metadata_done(batch_prefixes, self._session_id or "")
             exif_ms = (time.time() - exif_start) * 1000
             self._perf_add_stage('exif_flush', exif_ms)
             self._perf_stats['exif_flush_count'] += 1
@@ -982,6 +1080,11 @@ class PhotoProcessor:
             if not item or not item.get('file'):
                 return
             metadata_batch.append(item)
+            prefix = item.get('db_prefix')
+            if not prefix and item.get('file'):
+                prefix = os.path.splitext(os.path.basename(item['file']))[0]
+            if prefix:
+                metadata_batch_prefixes.append(prefix)
             if len(metadata_batch) >= metadata_batch_size:
                 flush_metadata_batch()
         
@@ -1383,6 +1486,8 @@ class PhotoProcessor:
             file_prefix = yolo_item['file_prefix']
             file_prefix = yolo_item['file_prefix']
             original_prefix = yolo_item['original_prefix']
+            if self.report_db:
+                self.report_db.mark_photo_running(original_prefix, self._session_id or "")
             
             # V4.1: 更新路径信息到数据库
             path_update_data = {}
@@ -1426,6 +1531,12 @@ class PhotoProcessor:
             result = yolo_item.get('result')
             if result is None:
                 self._log(yolo_item.get('error') or self.i18n.t("logs.cannot_process", filename=filename), "error")
+                if self.report_db:
+                    self.report_db.mark_photo_error(
+                        original_prefix,
+                        self._session_id or "",
+                        yolo_item.get('error') or self.i18n.t("logs.cannot_process", filename=filename)
+                    )
                 continue
             
             # V4.2: 解构 AI 结果（现在有 9 个返回值，包含 bird_count）
@@ -1474,6 +1585,8 @@ class PhotoProcessor:
                 
                 # 记录评分（用于文件移动）- V4.0.4: 使用 original_prefix 确保匹配 NEF
                 self.file_ratings[original_prefix] = rating_value
+                if self.report_db:
+                    self.report_db.mark_photo_analysis_done(original_prefix, self._session_id or "")
                 
                 # 写入简化 EXIF
                 if original_prefix in raw_dict:

--- a/core/recursive_scanner.py
+++ b/core/recursive_scanner.py
@@ -7,6 +7,7 @@
 """
 
 import os
+import sqlite3
 from typing import List, Set
 
 from constants import RAW_EXTENSIONS, JPG_EXTENSIONS, HEIF_EXTENSIONS, RATING_FOLDER_NAMES, RATING_FOLDER_NAMES_EN
@@ -46,7 +47,20 @@ def has_photos(dir_path: str) -> bool:
 
 def is_processed(dir_path: str) -> bool:
     """判断目录是否已被 SuperPicky 处理过（存在 report.db）"""
-    return os.path.exists(os.path.join(dir_path, '.superpicky', 'report.db'))
+    db_path = os.path.join(dir_path, '.superpicky', 'report.db')
+    if not os.path.exists(db_path):
+        return False
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            row = conn.execute("SELECT value FROM meta WHERE key = 'job_status'").fetchone()
+            if row and row[0] == 'running':
+                return False
+        finally:
+            conn.close()
+    except Exception:
+        pass
+    return True
 
 
 def scan_recursive(root: str, max_depth: int = 10) -> List[str]:

--- a/superpicky_cli.py
+++ b/superpicky_cli.py
@@ -142,6 +142,7 @@ def cmd_process(args):
     from tools.cli_processor import CLIProcessor
     from core.photo_processor import ProcessingSettings
     from advanced_config import get_advanced_config
+    from tools.report_db import ReportDB
     
     print_banner()
     print(t("cli.target_dir", directory=args.directory))
@@ -207,6 +208,31 @@ def cmd_process(args):
         verbose=not args.quiet,
         settings=settings
     )
+    
+    resume = False
+    resume_db = ReportDB(args.directory)
+    try:
+        snapshot = resume_db.get_resume_snapshot()
+    finally:
+        resume_db.close()
+
+    if snapshot.get('can_resume'):
+        if args.restart:
+            print("\n⚠️ 检测到未完成任务。`--restart` 不会自动回滚目录，请先执行 `reset` 后再重新处理。")
+            return 1
+        if args.resume:
+            resume = True
+        elif sys.stdin.isatty():
+            confirm = input("\n检测到未完成任务，是否继续上次处理? [y/N]: ")
+            if confirm.lower() in ['y', 'yes']:
+                resume = True
+            else:
+                print("已取消。若要重跑，请先执行 reset 后再重新处理。")
+                return 1
+        else:
+            print("\n⚠️ 检测到未完成任务。请显式传入 --resume 继续，或先执行 reset 后重跑。")
+            return 1
+    processor.resume = resume
     
     # 执行处理（PhotoProcessor 内部会处理自动识鸟）
     # 执行处理（PhotoProcessor 内部会处理自动识鸟）
@@ -1004,7 +1030,11 @@ Examples:
                           
     # V3.9: 使用 set_defaults 确保 flight, burst 默认为 True
     # V4.1: keep_temp 默认为 True
-    p_process.set_defaults(organize=True, cleanup=True, burst=True, flight=True, auto_identify=False, xmp=False, keep_temp=True)
+    p_process.add_argument('--resume', action='store_true',
+                          help='缁х画鏈畬鎴愮殑澶勭悊浠诲姟')
+    p_process.add_argument('--restart', action='store_true',
+                          help='涓嶈嚜鍔ㄥ洖婊氾紝闇€鍏堟墽琛?reset 鍚庡啀閲嶆柊澶勭悊')
+    p_process.set_defaults(organize=True, cleanup=True, burst=True, flight=True, auto_identify=False, xmp=False, keep_temp=True, resume=False, restart=False)
     
     # ===== reset 命令 =====
     p_reset = subparsers.add_parser('reset', help=t("cli.cmd_reset"))

--- a/superpicky_cli.py
+++ b/superpicky_cli.py
@@ -43,6 +43,21 @@ from tools.i18n import t
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 
+def _configure_cli_stdio():
+    """Use UTF-8-capable stdio in consoles to avoid help/error print crashes."""
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name, None)
+        if stream is None or not hasattr(stream, "reconfigure"):
+            continue
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
+
+
+_configure_cli_stdio()
+
+
 def print_banner():
     """打印 CLI 横幅"""
     print("\n" + "━" * 60)
@@ -1031,9 +1046,9 @@ Examples:
     # V3.9: 使用 set_defaults 确保 flight, burst 默认为 True
     # V4.1: keep_temp 默认为 True
     p_process.add_argument('--resume', action='store_true',
-                          help='缁х画鏈畬鎴愮殑澶勭悊浠诲姟')
+                          help='继续未完成的处理任务')
     p_process.add_argument('--restart', action='store_true',
-                          help='涓嶈嚜鍔ㄥ洖婊氾紝闇€鍏堟墽琛?reset 鍚庡啀閲嶆柊澶勭悊')
+                          help='不自动回滚，请先执行 reset 后再重新处理')
     p_process.set_defaults(organize=True, cleanup=True, burst=True, flight=True, auto_identify=False, xmp=False, keep_temp=True, resume=False, restart=False)
     
     # ===== reset 命令 =====

--- a/tools/cli_processor.py
+++ b/tools/cli_processor.py
@@ -100,7 +100,7 @@ class CLIProcessor:
         # 目前不显示，避免输出过多
         pass
     
-    def process(self, organize_files: bool = True, cleanup_temp: bool = True) -> Dict:
+    def process(self, organize_files: bool = True, cleanup_temp: bool = True, resume: bool = None) -> Dict:
         """
         主处理流程
         
@@ -115,9 +115,13 @@ class CLIProcessor:
         self._print_banner()
         
         # 调用核心处理器
+        if resume is None:
+            resume = getattr(self, "resume", False)
+
         result = self.processor.process(
             organize_files=organize_files,
-            cleanup_temp=cleanup_temp
+            cleanup_temp=cleanup_temp,
+            resume=resume
         )
         
         # 打印摘要

--- a/tools/report_db.py
+++ b/tools/report_db.py
@@ -15,13 +15,34 @@ import os
 import sqlite3
 import time
 import threading
+import uuid
 from datetime import datetime, timezone
 from typing import Optional, List, Dict, Any
 from .file_utils import ensure_hidden_directory
 
 
 # Schema 版本，用于未来升级
-SCHEMA_VERSION = "5"
+SCHEMA_VERSION = "6"
+
+JOB_STATUS_IDLE = "idle"
+JOB_STATUS_RUNNING = "running"
+JOB_STATUS_COMPLETED = "completed"
+JOB_STATUS_FAILED = "failed"
+
+JOB_STAGE_SCAN = "scan"
+JOB_STAGE_ANALYZE = "analyze"
+JOB_STAGE_PICKED = "picked"
+JOB_STAGE_ORGANIZE = "organize"
+JOB_STAGE_CLEANUP = "cleanup"
+JOB_STAGE_COMPLETED = "completed"
+
+PHOTO_STATE_PENDING = "pending"
+PHOTO_STATE_RUNNING = "running"
+PHOTO_STATE_DONE = "done"
+
+METADATA_STATE_PENDING = "pending"
+METADATA_STATE_QUEUED = "queued"
+METADATA_STATE_DONE = "done"
 
 # 所有列定义（有序），用于 CREATE TABLE 和数据验证
 PHOTO_COLUMNS = [
@@ -85,6 +106,11 @@ PHOTO_COLUMNS = [
     # V5: 连拍分组
     ("burst_id",         "INTEGER", None),
     ("burst_position",   "INTEGER", None),
+
+    ("analysis_state",   "TEXT", PHOTO_STATE_PENDING),
+    ("metadata_state",   "TEXT", METADATA_STATE_PENDING),
+    ("session_id",       "TEXT", None),
+    ("last_error",       "TEXT", None),
     
     ("created_at",    "TEXT", None),
     ("updated_at",    "TEXT", None),
@@ -185,6 +211,30 @@ class ReportDB:
                 self._conn.execute(
                     "INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)",
                     ("directory_path", self.directory)
+                )
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)",
+                    ("job_status", JOB_STATUS_IDLE)
+                )
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)",
+                    ("job_stage", JOB_STAGE_SCAN)
+                )
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)",
+                    ("job_session_id", "")
+                )
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)",
+                    ("job_settings_hash", "")
+                )
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)",
+                    ("job_started_at", "")
+                )
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)",
+                    ("job_updated_at", "")
                 )
 
         # Schema 升级在独立事务中执行，避免嵌套 commit 冲突
@@ -302,6 +352,39 @@ class ReportDB:
                     self._update_schema_version("5")
                 current_version = "5"
                 print("✅ Database schema upgraded to v5")
+
+            if current_version == "5":
+                print("Upgrading database schema from v5 to v6...")
+                new_columns_v6 = [
+                    ("analysis_state", "TEXT"),
+                    ("metadata_state", "TEXT"),
+                    ("session_id", "TEXT"),
+                    ("last_error", "TEXT"),
+                ]
+                with self._conn:
+                    for col_name, col_type in new_columns_v6:
+                        try:
+                            self._conn.execute(
+                                f"ALTER TABLE photos ADD COLUMN {col_name} {col_type}"
+                            )
+                        except sqlite3.OperationalError:
+                            pass
+                    self._conn.execute(
+                        "UPDATE photos SET analysis_state = ? "
+                        "WHERE analysis_state IS NULL OR TRIM(analysis_state) = ''",
+                        (PHOTO_STATE_PENDING,)
+                    )
+                    self._conn.execute(
+                        "UPDATE photos SET metadata_state = ? "
+                        "WHERE metadata_state IS NULL OR TRIM(metadata_state) = ''",
+                        (METADATA_STATE_PENDING,)
+                    )
+                    for key, value in self._default_meta_items().items():
+                        self._conn.execute(
+                            "INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)",
+                            (key, value)
+                        )
+                    self._update_schema_version("6")
 
     def _update_schema_version(self, version):
         """更新数据库中的版本号（由调用方负责提交事务）"""
@@ -831,6 +914,137 @@ class ReportDB:
     #  同步预留
     # ==========================================================================
 
+    def get_resume_snapshot(self) -> Dict[str, Any]:
+        """Return persisted resume state for the current directory."""
+        keys = (
+            "job_status",
+            "job_stage",
+            "job_session_id",
+            "job_settings_hash",
+            "job_started_at",
+            "job_updated_at",
+        )
+        snapshot = {key: self.get_meta(key) or "" for key in keys}
+        snapshot["incomplete_photos"] = self.get_incomplete_photo_prefixes()
+        snapshot["can_resume"] = (
+            snapshot["job_status"] == JOB_STATUS_RUNNING
+            and bool(snapshot["job_session_id"])
+            and len(snapshot["incomplete_photos"]) > 0
+        )
+        return snapshot
+
+    def begin_session(self, settings_hash: str, resume: bool = False) -> Dict[str, str]:
+        """Create or continue a processing session."""
+        now = _now_iso()
+        snapshot = self.get_resume_snapshot()
+        session_id = snapshot.get("job_session_id") if resume and snapshot.get("job_session_id") else uuid.uuid4().hex
+        started_at = snapshot.get("job_started_at") if resume and snapshot.get("job_started_at") else now
+        values = {
+            "job_status": JOB_STATUS_RUNNING,
+            "job_stage": snapshot.get("job_stage") or JOB_STAGE_SCAN,
+            "job_session_id": session_id,
+            "job_settings_hash": settings_hash or "",
+            "job_started_at": started_at,
+            "job_updated_at": now,
+        }
+        with self._lock:
+            self._set_meta_items(values)
+        return {"session_id": session_id, "started_at": started_at, "updated_at": now}
+
+    def set_job_stage(self, stage: str) -> None:
+        with self._lock:
+            self._set_meta_items({
+                "job_stage": stage,
+                "job_updated_at": _now_iso(),
+            })
+
+    def finish_session(self, status: str) -> None:
+        stage = JOB_STAGE_COMPLETED if status == JOB_STATUS_COMPLETED else self.get_meta("job_stage") or JOB_STAGE_SCAN
+        with self._lock:
+            self._set_meta_items({
+                "job_status": status,
+                "job_stage": stage,
+                "job_updated_at": _now_iso(),
+            })
+
+    def mark_photo_running(self, prefix: str, session_id: str) -> None:
+        self._mark_photo_state(
+            prefix,
+            analysis_state=PHOTO_STATE_RUNNING,
+            metadata_state=METADATA_STATE_PENDING,
+            session_id=session_id,
+            last_error=None,
+        )
+
+    def mark_photo_analysis_done(self, prefix: str, session_id: str) -> None:
+        self._mark_photo_state(
+            prefix,
+            analysis_state=PHOTO_STATE_DONE,
+            session_id=session_id,
+            last_error=None,
+        )
+
+    def mark_photo_error(self, prefix: str, session_id: str, error: str) -> None:
+        self._mark_photo_state(
+            prefix,
+            analysis_state=PHOTO_STATE_PENDING,
+            metadata_state=METADATA_STATE_PENDING,
+            session_id=session_id,
+            last_error=error,
+        )
+
+    def mark_photos_metadata_queued(self, prefixes: List[str], session_id: str) -> None:
+        self._mark_photos_metadata_state(prefixes, METADATA_STATE_QUEUED, session_id)
+
+    def mark_photos_metadata_done(self, prefixes: List[str], session_id: str) -> None:
+        self._mark_photos_metadata_state(prefixes, METADATA_STATE_DONE, session_id)
+
+    def get_incomplete_photo_prefixes(self) -> List[str]:
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT filename FROM photos "
+                "WHERE analysis_state IS NULL OR analysis_state != ? "
+                "OR metadata_state IS NULL OR metadata_state != ? "
+                "ORDER BY filename",
+                (PHOTO_STATE_DONE, METADATA_STATE_DONE)
+            )
+            return [row[0] for row in cursor.fetchall()]
+
+    def load_processing_summary(self) -> Dict[str, Any]:
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT filename, rating, adj_topiq, adj_sharpness, nima_score, head_sharp, "
+                "bird_species_cn, bird_species_en, current_path, original_path, temp_jpeg_path "
+                "FROM photos WHERE analysis_state = ? ORDER BY filename",
+                (PHOTO_STATE_DONE,)
+            )
+            photos = [dict(row) for row in cursor.fetchall()]
+
+        file_ratings: Dict[str, int] = {}
+        star_3_photos: List[Dict[str, Any]] = []
+        bird_species: Dict[str, Dict[str, Any]] = {}
+        for photo in photos:
+            prefix = photo["filename"]
+            rating = photo.get("rating")
+            if rating is not None:
+                file_ratings[prefix] = int(rating)
+            if int(photo.get("rating") or 0) == 3:
+                star_3_photos.append({
+                    "file": photo.get("current_path") or photo.get("original_path") or photo.get("temp_jpeg_path") or prefix,
+                    "nima": photo.get("adj_topiq") if photo.get("adj_topiq") is not None else photo.get("nima_score"),
+                    "sharpness": photo.get("adj_sharpness") if photo.get("adj_sharpness") is not None else photo.get("head_sharp"),
+                })
+            cn_name = photo.get("bird_species_cn")
+            en_name = photo.get("bird_species_en")
+            if cn_name or en_name:
+                bird_species[prefix] = {"cn_name": cn_name, "en_name": en_name}
+
+        return {
+            "file_ratings": file_ratings,
+            "star_3_photos": star_3_photos,
+            "bird_species": bird_species,
+        }
+
     def get_updated_since(self, since: str) -> List[dict]:
         """
         获取指定时间之后更新的记录（增量同步用）。
@@ -869,6 +1083,59 @@ class ReportDB:
     # ==========================================================================
     #  内部方法
     # ==========================================================================
+
+    @staticmethod
+    def _default_meta_items() -> Dict[str, str]:
+        return {
+            "job_status": JOB_STATUS_IDLE,
+            "job_stage": JOB_STAGE_SCAN,
+            "job_session_id": "",
+            "job_settings_hash": "",
+            "job_started_at": "",
+            "job_updated_at": "",
+        }
+
+    def _set_meta_items(self, values: Dict[str, str]) -> None:
+        for key, value in values.items():
+            self._conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+                (key, value)
+            )
+        self._safe_commit()
+
+    def _mark_photo_state(
+        self,
+        prefix: str,
+        analysis_state: Optional[str] = None,
+        metadata_state: Optional[str] = None,
+        session_id: Optional[str] = None,
+        last_error: Optional[str] = None,
+    ) -> None:
+        data: Dict[str, Any] = {}
+        if analysis_state is not None:
+            data["analysis_state"] = analysis_state
+        if metadata_state is not None:
+            data["metadata_state"] = metadata_state
+        if session_id is not None:
+            data["session_id"] = session_id
+        data["last_error"] = last_error
+        self.update_photo(prefix, data)
+
+    def _mark_photos_metadata_state(self, prefixes: List[str], state: str, session_id: str) -> None:
+        prefixes = [prefix for prefix in prefixes if prefix]
+        if not prefixes:
+            return
+        now = _now_iso()
+        placeholders = ", ".join(["?"] * len(prefixes))
+        values: List[Any] = [state, session_id, now]
+        values.extend(prefixes)
+        with self._lock:
+            self._conn.execute(
+                f"UPDATE photos SET metadata_state = ?, session_id = ?, updated_at = ? "
+                f"WHERE filename IN ({placeholders})",
+                values
+            )
+            self._safe_commit()
 
     def _safe_commit(self) -> None:
         """仅在存在活动事务时提交，兼容 autocommit 场景。"""
@@ -939,6 +1206,10 @@ class ReportDB:
             # shutter_speed, aperture, camera_model, lens_model,
             # title, caption, city, state_province, country,
             # date_time_original, bird_species_cn, bird_species_en, exposure_status
+            if key in ("analysis_state", "metadata_state", "session_id", "last_error"):
+                cleaned[key] = str(value)
+                continue
+
             cleaned[key] = value
 
         return cleaned

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -85,12 +85,13 @@ class WorkerSignals(QObject):
 class WorkerThread(threading.Thread):
     """处理线程"""
 
-    def __init__(self, dir_path, ui_settings, signals, i18n=None):
+    def __init__(self, dir_path, ui_settings, signals, i18n=None, resume=False):
         super().__init__(daemon=True)
         self.dir_path = dir_path
         self.ui_settings = ui_settings
         self.signals = signals
         self.i18n = i18n
+        self.resume = resume
         self._stop_event = threading.Event()
         self.caffeinate_process = None
 
@@ -357,7 +358,8 @@ class WorkerThread(threading.Thread):
 
             result = processor.process(
                 organize_files=True,
-                cleanup_temp=not adv_config.keep_temp_files
+                cleanup_temp=not adv_config.keep_temp_files,
+                resume=self.resume
             )
 
             burst_groups = result.stats.get('burst_groups', 0)
@@ -439,7 +441,8 @@ class WorkerThread(threading.Thread):
                 try:
                     result = processor.process(
                         organize_files=True,
-                        cleanup_temp=not adv_config.keep_temp_files
+                        cleanup_temp=not adv_config.keep_temp_files,
+                        resume=self.resume
                     )
                     s = result.stats
                     for key in ('total', 'star_3', 'picked', 'star_2', 'star_1',
@@ -1505,6 +1508,14 @@ class SuperPickyMainWindow(QMainWindow):
         """打开/切换结果浏览器窗口，并隐藏主窗口。"""
         if not self.directory_path:
             return
+
+        try:
+            from tools.report_db import ReportDB
+            resume_snapshot = ReportDB(self.directory_path).get_resume_snapshot()
+            if resume_snapshot.get("job_status") == "running":
+                return
+        except Exception:
+            pass
         from ui.results_browser_window import ResultsBrowserWindow
         if not hasattr(self, '_results_browser') or self._results_browser is None:
             self._results_browser = ResultsBrowserWindow(parent=None)
@@ -1674,7 +1685,18 @@ class SuperPickyMainWindow(QMainWindow):
 
         report_path = os.path.join(self.directory_path, ".superpicky", "report.db")
         if os.path.exists(report_path):
+            resume_snapshot = None
+            try:
+                from tools.report_db import ReportDB
+                resume_snapshot = ReportDB(self.directory_path).get_resume_snapshot()
+            except Exception:
+                resume_snapshot = None
+
             counts = self._load_result_counts()
+            if resume_snapshot and resume_snapshot.get("job_status") == "running":
+                self._update_status_banner("ready", counts)
+                self._update_action_buttons("ready")
+                return
             self._update_status_banner("has_results", counts)
             self._update_action_buttons("has_results")
             # 只有保留预览图时才自动弹出浏览器（无预览图时浏览器无内容）
@@ -1766,6 +1788,30 @@ class SuperPickyMainWindow(QMainWindow):
         if reply != StyledMessageBox.Yes:
             return
 
+        resume_processing = False
+        try:
+            from tools.report_db import ReportDB
+            resume_db = ReportDB(self.directory_path)
+            try:
+                snapshot = resume_db.get_resume_snapshot()
+            finally:
+                resume_db.close()
+            if snapshot.get('can_resume'):
+                resume_reply = StyledMessageBox.question(
+                    self,
+                    "检测到未完成任务",
+                    "这个目录有一次未完成的处理任务。选择“是”继续上次处理，选择“否”先恢复目录后重新开始。",
+                    yes_text="继续处理",
+                    no_text="重新开始"
+                )
+                if resume_reply == StyledMessageBox.Yes:
+                    resume_processing = True
+                else:
+                    self._quick_restore_directory()
+                    return
+        except Exception as resume_err:
+            self._log(f"⚠️ 恢复状态检查失败: {resume_err}", "warning")
+
         # 清空日志和进度
         self.log_text.clear()
         self.progress_bar.setValue(0)
@@ -1807,7 +1853,8 @@ class SuperPickyMainWindow(QMainWindow):
             self.directory_path,
             ui_settings,
             self.worker_signals,
-            self.i18n
+            self.i18n,
+            resume=resume_processing
         )
         self.worker.start()
 


### PR DESCRIPTION
This PR reapplies the interrupted processing job resume tracking that was previously submitted in PR #63 and later reverted as part of the nightly rollback.\n\nContext:\n- PR #63 originally introduced resume tracking for interrupted processing jobs\n- Those changes were later removed during the nightly rollback/revert flow\n- Now that dev has completed the branch role transition, this reapplies that functionality directly onto dev\n\nValidation:\n- python -m py_compile core/photo_processor.py core/recursive_scanner.py superpicky_cli.py tools/cli_processor.py tools/report_db.py ui/main_window.py