### PR TITLE
Use file-based resume state and tighten GUI shutdown

### DIFF
--- a/core/photo_processor.py
+++ b/core/photo_processor.py
@@ -35,6 +35,7 @@ from ai_model import load_yolo_model, detect_and_draw_birds
 from tools.report_db import ReportDB
 from tools.exiftool_manager import get_exiftool_manager
 from tools.file_utils import ensure_hidden_directory
+from tools.resume_state import ResumeStateManager
 from advanced_config import get_advanced_config
 from core.rating_engine import RatingEngine, create_rating_engine_from_config
 from core.keypoint_detector import KeypointDetector, get_keypoint_detector
@@ -79,6 +80,7 @@ class ProcessingCallbacks:
     """回调函数（用于进度更新和日志输出）"""
     log: Optional[Callable[[str, str], None]] = None
     progress: Optional[Callable[[int], None]] = None
+    should_stop: Optional[Callable[[], bool]] = None
     crop_preview: Optional[Callable[[any], None]] = None  # V4.2: 裁剪预览回调
 
 
@@ -90,6 +92,10 @@ class ProcessingResult:
     star_3_photos: List[Dict] = field(default_factory=list)
     total_time: float = 0.0
     avg_time: float = 0.0
+
+
+class ProcessingCancelled(RuntimeError):
+    """Raised when processing is cancelled by the caller."""
 
 
 class PhotoProcessor:
@@ -174,6 +180,8 @@ class PhotoProcessor:
         self.burst_map = {}  # V4.0.4: Track burst group IDs: {filepath: group_id}, 0 = not a burst
         # SQLite 报告数据库（替代 CSV 缓存）
         self.report_db = None  # 在 _run_ai_detection 中初始化
+        self.resume_state = ResumeStateManager(dir_path)
+        self._stop_requested = False
         
         # 性能日志开关（支持 settings 和环境变量）
         env_perf = os.getenv("SUPERPICKY_PERF_LOG", "").strip().lower() in {"1", "true", "yes", "on"}
@@ -210,6 +218,23 @@ class PhotoProcessor:
         """内部进度更新"""
         if self.callbacks.progress:
             self.callbacks.progress(percent)
+
+    def request_stop(self) -> None:
+        self._stop_requested = True
+
+    def _should_stop(self) -> bool:
+        if self._stop_requested:
+            return True
+        if not self.callbacks.should_stop:
+            return False
+        try:
+            return bool(self.callbacks.should_stop())
+        except Exception:
+            return False
+
+    def _check_cancelled(self) -> None:
+        if self._should_stop():
+            raise ProcessingCancelled("Processing cancelled")
     
     def _perf_add_stage(self, stage: str, ms: float):
         """累计阶段耗时（毫秒）"""
@@ -463,11 +488,19 @@ class PhotoProcessor:
         penalty = self.ISO_PENALTY_FACTOR * math.log2(iso_value / self.ISO_BASE)
         factor = max(self.ISO_MIN_FACTOR, 1.0 - penalty)
         return factor
+
+    @staticmethod
+    def _resume_prefix(filename: str) -> str:
+        return os.path.splitext(os.path.basename(filename))[0]
+
+    def _sort_processing_files(self, files_tbr: List[str]) -> List[str]:
+        return sorted(files_tbr, key=lambda item: self._resume_prefix(item).lower())
     
     def process(
         self,
         organize_files: bool = True,
-        cleanup_temp: bool = True
+        cleanup_temp: bool = True,
+        resume: bool = False
     ) -> ProcessingResult:
         """
         主处理流程
@@ -493,9 +526,27 @@ class PhotoProcessor:
         raw_files_to_convert = self._identify_raws_to_convert(raw_dict, jpg_dict, files_tbr)
         if raw_files_to_convert:
             self._convert_raws(raw_files_to_convert, files_tbr)
+
+        files_tbr = self._sort_processing_files(files_tbr)
+        display_start = 1
+        display_total = len(files_tbr)
+        ordered_prefixes = [self._resume_prefix(item) for item in files_tbr]
+        if resume:
+            plan = self.resume_state.get_resume_plan(ordered_prefixes)
+            if plan:
+                prefix_to_file = {self._resume_prefix(item): item for item in files_tbr}
+                files_tbr = [prefix_to_file[prefix] for prefix in plan["pending_prefixes"] if prefix in prefix_to_file]
+                display_start = int(plan["next_index"])
+                display_total = int(plan["total_files"])
+            else:
+                self.resume_state.start(ordered_prefixes)
+        else:
+            self.resume_state.start(ordered_prefixes)
+
+        self._check_cancelled()
         
         # 阶段3: AI检测与评分
-        self._process_images(files_tbr, raw_dict)
+        self._process_images(files_tbr, raw_dict, display_start=display_start, display_total=display_total)
         
         # 阶段4: 精选旗标计算（metadata_write_mode=none 时跳过）
         if get_advanced_config().get_metadata_write_mode() != "none":
@@ -533,6 +584,9 @@ class PhotoProcessor:
         # 关闭数据库连接（在所有阶段完成后）
         if hasattr(self, 'report_db') and self.report_db:
             self.report_db.close()
+            self.report_db = None
+
+        self.resume_state.clear()
         
         return ProcessingResult(
             stats=self.stats.copy(),
@@ -878,7 +932,7 @@ class PhotoProcessor:
         time_str = f"{raw_time:.1f}s" if raw_time >= 1 else f"{raw_time*1000:.0f}ms"
         self._log(self.i18n.t("logs.raw_conversion_time", time_str=time_str, avg=avg_time))
     
-    def _process_images(self, files_tbr, raw_dict):
+    def _process_images(self, files_tbr, raw_dict, display_start: int = 1, display_total: int = None):
         """处理所有图片 - AI检测、关键点检测与评分"""
         # 获取模型（已在启动时预加载，此处仅获取引用）
         model = load_yolo_model()
@@ -907,8 +961,12 @@ class PhotoProcessor:
                 self._log("⚠️  Flight model not found, skipping flight detection", "warning")
                 use_flight = False
         
-        total_files = len(files_tbr)
+        total_files = display_total if display_total is not None else len(files_tbr)
         self._log(self.i18n.t("logs.files_to_process", total=total_files))
+
+        def mark_resume_completed(prefix: str):
+            if prefix:
+                self.resume_state.mark_completed(prefix)
         
         exiftool_mgr = get_exiftool_manager()
         metadata_batch: List[Dict] = []
@@ -1299,6 +1357,35 @@ class PhotoProcessor:
         exif_prefetch_results = {}
         exif_prefetch_done = False
         exif_prefetch_cond = threading.Condition()
+
+        def cancel_processing() -> None:
+            if not self._should_stop():
+                return
+            if metadata_async_enabled and metadata_queue is not None:
+                try:
+                    metadata_queue.put_nowait(None)
+                except Exception:
+                    pass
+            if birdid_executor is not None:
+                try:
+                    birdid_executor.shutdown(wait=False, cancel_futures=True)
+                except TypeError:
+                    birdid_executor.shutdown(wait=False)
+                except Exception:
+                    pass
+            try:
+                inference_pool.shutdown(wait=False, cancel_futures=True)
+            except TypeError:
+                inference_pool.shutdown(wait=False)
+            except Exception:
+                pass
+            if self.report_db:
+                try:
+                    self.report_db.close()
+                except Exception:
+                    pass
+                self.report_db = None
+            raise ProcessingCancelled("Processing cancelled")
         
         if exif_prefetch_enabled:
             def exif_prefetch_worker():
@@ -1334,7 +1421,9 @@ class PhotoProcessor:
         elif self._perf_enabled:
             self._log("  ⚙️ EXIF prefetch: off")
 
-        for i in range(1, total_files + 1):
+        for local_index in range(1, len(files_tbr) + 1):
+            cancel_processing()
+            i = display_start + local_index - 1
             photo_stage_ms = {}
             
             def add_photo_stage(stage: str, ms: float):
@@ -1346,14 +1435,20 @@ class PhotoProcessor:
             # 从预取队列获取 YOLO 结果；未启用预取时回退为同步执行
             if yolo_result_queue is not None:
                 yolo_wait_start = time.time()
-                yolo_item = yolo_result_queue.get()
+                while True:
+                    cancel_processing()
+                    try:
+                        yolo_item = yolo_result_queue.get(timeout=0.1)
+                        break
+                    except queue.Empty:
+                        continue
                 yolo_wait_ms = (time.time() - yolo_wait_start) * 1000
                 if yolo_wait_ms > 0.1:
                     add_photo_stage('yolo_queue_wait', yolo_wait_ms)
                 if yolo_item is None:
                     break
             else:
-                filename_inline = files_tbr[i - 1]
+                filename_inline = files_tbr[local_index - 1]
                 yolo_item = build_yolo_item(i, filename_inline)
             
             prefetched_exif = None
@@ -1361,10 +1456,11 @@ class PhotoProcessor:
             if exif_prefetch_enabled:
                 exif_wait_start = time.time()
                 with exif_prefetch_cond:
-                    while i not in exif_prefetch_results and not exif_prefetch_done:
+                    while local_index not in exif_prefetch_results and not exif_prefetch_done:
+                        cancel_processing()
                         exif_prefetch_cond.wait(timeout=0.01)
-                    if i in exif_prefetch_results:
-                        prefetched_exif = exif_prefetch_results.pop(i)
+                    if local_index in exif_prefetch_results:
+                        prefetched_exif = exif_prefetch_results.pop(local_index)
                         exif_prefetched = True
                 exif_wait_ms = (time.time() - exif_wait_start) * 1000
                 if exif_wait_ms > 0.1:
@@ -1426,6 +1522,7 @@ class PhotoProcessor:
             result = yolo_item.get('result')
             if result is None:
                 self._log(yolo_item.get('error') or self.i18n.t("logs.cannot_process", filename=filename), "error")
+                mark_resume_completed(original_prefix)
                 continue
             
             # V4.2: 解构 AI 结果（现在有 9 个返回值，包含 bird_count）
@@ -1491,6 +1588,7 @@ class PhotoProcessor:
                             'caption': f"{rating_value}星 | {reason}",
                         })
                 
+                mark_resume_completed(original_prefix)
                 self._perf_record_photo(photo_time_ms, photo_stage_ms, early_exit=True)
 
                 # 即使置信度不足，只要检测到鸟就生成 crop_debug 供浏览预览
@@ -2130,7 +2228,29 @@ class PhotoProcessor:
                         self.star2_reasons[file_prefix] = 'both'
             
             self._perf_record_photo(photo_time_ms, photo_stage_ms, early_exit=False)
+            mark_resume_completed(original_prefix)
         
+        if self._should_stop():
+            if metadata_async_enabled and metadata_queue is not None:
+                try:
+                    metadata_queue.put_nowait(None)
+                except Exception:
+                    pass
+            if birdid_executor is not None:
+                try:
+                    birdid_executor.shutdown(wait=False, cancel_futures=True)
+                except TypeError:
+                    birdid_executor.shutdown(wait=False)
+                except Exception:
+                    pass
+            try:
+                inference_pool.shutdown(wait=False, cancel_futures=True)
+            except TypeError:
+                inference_pool.shutdown(wait=False)
+            except Exception:
+                pass
+            raise ProcessingCancelled("Processing cancelled")
+
         if yolo_prefetch_thread is not None:
             try:
                 yolo_prefetch_thread.join(timeout=30)

--- a/tools/resume_state.py
+++ b/tools/resume_state.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import json
+import os
+import tempfile
+from typing import Dict, List, Optional
+
+from .file_utils import ensure_hidden_directory
+
+
+class ResumeStateManager:
+    """Persist lightweight resume state outside the report database."""
+
+    FILENAME = "resume_state.json"
+
+    def __init__(self, directory: str):
+        self.directory = directory
+        self.state_dir = os.path.join(directory, ".superpicky")
+        self.state_path = os.path.join(self.state_dir, self.FILENAME)
+
+    def exists(self) -> bool:
+        return os.path.exists(self.state_path)
+
+    def load(self) -> Optional[Dict]:
+        if not self.exists():
+            return None
+        try:
+            with open(self.state_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                return data
+        except Exception:
+            return None
+        return None
+
+    def start(self, ordered_prefixes: List[str]) -> None:
+        payload = {
+            "version": 1,
+            "status": "running",
+            "total_files": len(ordered_prefixes),
+            "next_index": 1,
+            "pending_prefixes": list(ordered_prefixes),
+        }
+        self._write(payload)
+
+    def get_resume_plan(self, available_prefixes: List[str]) -> Optional[Dict]:
+        state = self.load()
+        if not state or state.get("status") != "running":
+            return None
+        available_set = set(available_prefixes)
+        pending = [prefix for prefix in (state.get("pending_prefixes") or []) if prefix in available_set]
+        if not pending:
+            return None
+        total_files = int(state.get("total_files") or len(available_prefixes))
+        completed = max(0, total_files - len(pending))
+        return {
+            "total_files": total_files,
+            "next_index": completed + 1,
+            "pending_prefixes": pending,
+        }
+
+    def mark_completed(self, prefix: str) -> None:
+        state = self.load()
+        if not state:
+            return
+        pending = [item for item in (state.get("pending_prefixes") or []) if item != prefix]
+        state["pending_prefixes"] = pending
+        total_files = int(state.get("total_files") or 0)
+        state["next_index"] = min(total_files + 1, total_files - len(pending) + 1) if total_files > 0 else 1
+        if not pending:
+            self.clear()
+            return
+        self._write(state)
+
+    def clear(self) -> None:
+        try:
+            if self.exists():
+                os.remove(self.state_path)
+        except FileNotFoundError:
+            pass
+
+    def _write(self, payload: Dict) -> None:
+        ensure_hidden_directory(self.state_dir)
+        fd, temp_path = tempfile.mkstemp(prefix="resume_", suffix=".json", dir=self.state_dir)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f, ensure_ascii=False, indent=2)
+            os.replace(temp_path, self.state_path)
+        finally:
+            try:
+                if os.path.exists(temp_path):
+                    os.remove(temp_path)
+            except Exception:
+                pass

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -85,13 +85,15 @@ class WorkerSignals(QObject):
 class WorkerThread(threading.Thread):
     """处理线程"""
 
-    def __init__(self, dir_path, ui_settings, signals, i18n=None):
+    def __init__(self, dir_path, ui_settings, signals, i18n=None, resume=False):
         super().__init__(daemon=True)
         self.dir_path = dir_path
         self.ui_settings = ui_settings
         self.signals = signals
         self.i18n = i18n
+        self.resume = resume
         self._stop_event = threading.Event()
+        self._active_processor = None
         self.caffeinate_process = None
 
         self.stats = {
@@ -115,9 +117,20 @@ class WorkerThread(threading.Thread):
             self.process_files()
             self.signals.finished.emit(self.stats)
         except Exception as e:
-            self.signals.error.emit(str(e))
+            if e.__class__.__name__ == "ProcessingCancelled":
+                self.signals.log.emit("Processing cancelled.", "warning")
+            else:
+                self.signals.error.emit(str(e))
         finally:
             self._stop_caffeinate()
+
+    def request_stop(self):
+        self._stop_event.set()
+        if self._active_processor is not None:
+            try:
+                self._active_processor.request_stop()
+            except Exception:
+                pass
 
     def _start_caffeinate(self):
         """启动防休眠"""
@@ -337,6 +350,7 @@ class WorkerThread(threading.Thread):
         callbacks = ProcessingCallbacks(
             log=log_callback,
             progress=progress_callback,
+            should_stop=self._stop_event.is_set,
             crop_preview=crop_preview_callback
         )
 
@@ -351,24 +365,29 @@ class WorkerThread(threading.Thread):
                 settings=settings,
                 callbacks=callbacks
             )
+            self._active_processor = processor
 
             from advanced_config import get_advanced_config
             adv_config = get_advanced_config()
 
-            result = processor.process(
-                organize_files=True,
-                cleanup_temp=not adv_config.keep_temp_files
-            )
+            try:
+                result = processor.process(
+                    organize_files=True,
+                    cleanup_temp=not adv_config.keep_temp_files,
+                    resume=self.resume
+                )
 
-            burst_groups = result.stats.get('burst_groups', 0)
-            burst_moved = result.stats.get('burst_moved', 0)
+                burst_groups = result.stats.get('burst_groups', 0)
+                burst_moved = result.stats.get('burst_moved', 0)
 
-            if burst_groups > 0:
-                log_callback(self.i18n.t("logs.burst_complete", groups=burst_groups, moved=burst_moved), "success")
-            elif settings.detect_burst:
-                log_callback(self.i18n.t("logs.burst_none_detected"), "info")
+                if burst_groups > 0:
+                    log_callback(self.i18n.t("logs.burst_complete", groups=burst_groups, moved=burst_moved), "success")
+                elif settings.detect_burst:
+                    log_callback(self.i18n.t("logs.burst_none_detected"), "info")
 
-            self.stats = result.stats
+                self.stats = result.stats
+            finally:
+                self._active_processor = None
         else:
             # Batch mode: process each subdirectory
             from advanced_config import get_advanced_config
@@ -427,6 +446,7 @@ class WorkerThread(threading.Thread):
                 sub_callbacks = ProcessingCallbacks(
                     log=log_callback,
                     progress=make_progress_cb(dir_base, dir_count),
+                    should_stop=self._stop_event.is_set,
                     crop_preview=crop_preview_callback
                 )
 
@@ -435,11 +455,13 @@ class WorkerThread(threading.Thread):
                     settings=settings,
                     callbacks=sub_callbacks
                 )
+                self._active_processor = processor
 
                 try:
                     result = processor.process(
                         organize_files=True,
-                        cleanup_temp=not adv_config.keep_temp_files
+                        cleanup_temp=not adv_config.keep_temp_files,
+                        resume=self.resume
                     )
                     s = result.stats
                     for key in ('total', 'star_3', 'picked', 'star_2', 'star_1',
@@ -461,6 +483,8 @@ class WorkerThread(threading.Thread):
                     )
                 except Exception as e:
                     log_callback(f"  \u274c Error: {e}", "error")
+                finally:
+                    self._active_processor = None
 
                 processed_so_far += dir_count
 
@@ -626,6 +650,8 @@ class SuperPickyMainWindow(QMainWindow):
         self._setup_system_tray()
         self._really_quit = False  # 标记是否真正退出
         self._background_mode = False  # V4.0: 标记是否进入后台模式（不停止服务器）
+        self._suppress_results_browser_once = False
+        self._resume_prompt_handled = False
         
         # osk flex,countly.com 63fda2e
         self._startup_prompts_ran = False
@@ -941,6 +967,12 @@ class SuperPickyMainWindow(QMainWindow):
         无论通过 X按鈕 / Cmd+Q / 托盘退出，都会经过此处。
         Mac 和 Windows 均适用。
         """
+        if self.worker and self.worker.is_alive():
+            try:
+                self.worker.request_stop()
+                self.worker.join(timeout=5)
+            except Exception:
+                pass
         if hasattr(self, '_results_browser') and self._results_browser:
             try:
                 self._results_browser.cleanup()
@@ -1475,9 +1507,36 @@ class SuperPickyMainWindow(QMainWindow):
 
         # 状态条 + 按钮由 _check_report_csv 根据是否有历史数据决定
         # 重置弹窗移到「重新处理」按钮点击时再询问（_reset_directory 保留确认逻辑）
+        self._resume_prompt_handled = False
         self._check_report_csv()
+        self._maybe_prompt_resume_after_selection()
 
     # ========== 状态条 + 结果浏览器辅助 ==========
+
+    def _maybe_prompt_resume_after_selection(self):
+        if self._resume_prompt_handled or not self.directory_path:
+            return
+        self._resume_prompt_handled = True
+        try:
+            from tools.resume_state import ResumeStateManager
+            resume_state = ResumeStateManager(self.directory_path)
+            if not resume_state.exists():
+                return
+            resume_reply = StyledMessageBox.question(
+                self,
+                "检测到未完成任务",
+                "这个目录存在未完成的处理记录。选择“继续处理”会从上次中断的位置继续；选择“重新开始”会先恢复目录，再重新处理。",
+                yes_text="继续处理",
+                no_text="重新开始"
+            )
+            if resume_reply == StyledMessageBox.Yes:
+                self._start_processing()
+            else:
+                resume_state.clear()
+                self._suppress_results_browser_once = True
+                self._quick_restore_directory()
+        except Exception as resume_err:
+            self._log(f"⚠️ 恢复状态检查失败: {resume_err}", "warning")
 
     def _load_result_counts(self) -> dict:
         """从 report.db 读取评分统计，供状态条显示。"""
@@ -1672,6 +1731,15 @@ class SuperPickyMainWindow(QMainWindow):
         if not self.directory_path:
             return
 
+        try:
+            from tools.resume_state import ResumeStateManager
+            if ResumeStateManager(self.directory_path).exists():
+                self._update_status_banner("ready")
+                self._update_action_buttons("ready")
+                return
+        except Exception:
+            pass
+
         report_path = os.path.join(self.directory_path, ".superpicky", "report.db")
         if os.path.exists(report_path):
             counts = self._load_result_counts()
@@ -1766,6 +1834,32 @@ class SuperPickyMainWindow(QMainWindow):
         if reply != StyledMessageBox.Yes:
             return
 
+        resume_processing = False
+        try:
+            from tools.resume_state import ResumeStateManager
+            resume_state = ResumeStateManager(self.directory_path)
+            if resume_state.exists() and self._resume_prompt_handled:
+                resume_processing = True
+            elif resume_state.exists():
+                resume_reply = StyledMessageBox.question(
+                    self,
+                    "检测到未完成任务",
+                    "这个目录存在未完成的处理记录。选择“继续处理”会从上次中断的位置继续；选择“重新开始”会先恢复目录，再重新处理。",
+                    yes_text="继续处理",
+                    no_text="重新开始"
+                )
+                if resume_reply == StyledMessageBox.Yes:
+                    resume_processing = True
+                else:
+                    resume_state.clear()
+                    self._suppress_results_browser_once = True
+                    self._quick_restore_directory()
+                    return
+        except Exception as resume_err:
+            self._log(f"⚠️ 恢复状态检查失败: {resume_err}", "warning")
+        finally:
+            self._resume_prompt_handled = False
+
         # 清空日志和进度
         self.log_text.clear()
         self.progress_bar.setValue(0)
@@ -1807,7 +1901,8 @@ class SuperPickyMainWindow(QMainWindow):
             self.directory_path,
             ui_settings,
             self.worker_signals,
-            self.i18n
+            self.i18n,
+            resume=resume_processing
         )
         self.worker.start()
 
@@ -2165,6 +2260,11 @@ class SuperPickyMainWindow(QMainWindow):
         else:
             self._update_status(self.i18n.t("labels.error"), COLORS['error'])
             self._log(self.i18n.t("messages.reset_failed_log"))
+        if self._suppress_results_browser_once:
+            self._suppress_results_browser_once = False
+            self._update_status_banner("ready")
+            self._update_action_buttons("ready")
+            return
 
         self._check_report_csv()
 
@@ -2521,9 +2621,10 @@ class SuperPickyMainWindow(QMainWindow):
             )
 
             if reply == StyledMessageBox.No:  # 用户点击"是"退出
-                self.worker._stop_event.set()
+                self.worker.request_stop()
                 self.worker._stop_caffeinate()  # V3.8.1: 确保终止 caffeinate 进程
                 self._stop_birdid_server()  # V4.0: 停止识鸟 API 服务
+                self._quit_app()
                 event.accept()
             else:
                 event.ignore()


### PR DESCRIPTION
Clean replacement for PR73 with a single commit. Replace DB-based resume tracking with .superpicky/resume_state.json, show the resume prompt from the main window when reselecting an interrupted directory, and propagate stop requests so closing the UI shuts down background work more directly.