### PR TITLE
[Refactor] Unify half-precision inference logic using torch.autocast

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -26,13 +26,16 @@ def load_yolo_model(log_callback=None):
         device = get_best_device()
         i18n = get_i18n()
         
-        # 使用 i18n 翻译设备类型消息
+        # 使用 i18n 翻译设备类型消息，借用这个流程增加模型半精度推理开关
         if device.type == 'mps':
             msg = i18n.t("ai.using_mps")
+            model._precision_mode = "fp16"
         elif device.type == 'cuda':
             msg = i18n.t("ai.using_cuda")
+            model._precision_mode = "fp16"
         else:
             msg = i18n.t("ai.using_cpu")
+            model._precision_mode = "fp32"
         
         # 使用日志回调或直接打印
         if log_callback:
@@ -46,6 +49,7 @@ def load_yolo_model(log_callback=None):
             log_callback(error_msg, "warning")
         else:
             print(error_msg)
+        model._precision_mode = "fp32"
 
     return model
 
@@ -138,13 +142,15 @@ def detect_and_draw_birds(image_path, model, output_path, dir, ui_settings, i18n
         device = get_best_device()
         
         # 使用最佳设备进行推理
-        results = model(image, device=device.type)
+        # results = model(image, device=device.type)
+        results = model(image, device=device.type, half=getattr(model, '_precision_mode', "fp32") == "fp16")
     except Exception as device_error:
         # 设备推理失败，降级到CPU
         t = i18n.t if i18n else get_i18n().t
         log_message(t("ai.device_inference_failed", error=device_error), dir)
         try:
-            results = model(image, device='cpu')
+            # results = model(image, device='cpu')
+            results = model(image, device='cpu', half=False)
         except Exception as cpu_error:
             log_message(t("ai.ai_inference_failed", error=cpu_error), dir)
             # 返回"无鸟"结果（V3.1）

--- a/birdid/bird_identifier.py
+++ b/birdid/bird_identifier.py
@@ -156,6 +156,15 @@ def get_classifier():
             model.load_state_dict(state_dict)
             model = model.to(CLASSIFIER_DEVICE)
             model.eval()
+
+            # V4.2.2：统一半精度处理规则
+            if CLASSIFIER_DEVICE.type in ("cuda", "mps"):
+                model._precision_mode = "fp16"
+                model._amp_dtype = torch.float16
+            else:
+                model._precision_mode = "fp32"
+                model._amp_dtype = torch.float32
+
             _classifier = model
             print(f"[BirdID] OSEA ResNet34 model loaded, device: {CLASSIFIER_DEVICE}")
         else:
@@ -176,6 +185,9 @@ def get_classifier():
             else:
                 raise RuntimeError(f"未找到分类模型: {MODEL_PATH} 或 {MODEL_PATH_LEGACY}")
             _classifier.eval()
+            # V4.2.2：统一半精度处理规则
+            _classifier._precision_mode = "fp32"
+            _classifier._amp_dtype = torch.float32
             print(_t("logs.birdid_fallback_model"))
     return _classifier
 
@@ -244,6 +256,12 @@ class YOLOBirdDetector:
             print(_t("logs.yolo_load_failed", e=e))
             self.model = None
 
+        # V4.2.2：统一半精度处理规则
+        if CLASSIFIER_DEVICE.type in ("cuda", "mps"):
+            self._precision_mode = "fp16"
+        else:
+            self._precision_mode = "fp32"
+
     def detect_and_crop_bird(
         self,
         image_input,
@@ -281,7 +299,14 @@ class YOLOBirdDetector:
                 return None, "不支持的图像输入类型"
 
             img_array = np.array(image)
-            results = self.model(img_array, conf=confidence_threshold)
+            # V4.2.2：统一半精度推理结果
+            # results = self.model(img_array, conf=confidence_threshold)
+            results = self.model(
+                img_array,
+                conf=confidence_threshold,
+                device=CLASSIFIER_DEVICE,
+                half=(self._precision_mode == "fp16")
+            )
 
             detections = []
             for result in results:
@@ -724,9 +749,20 @@ def predict_bird(
     transform = OSEA_TRANSFORM_DIRECT if is_yolo_cropped else OSEA_TRANSFORM
     input_tensor = transform(image).unsqueeze(0).to(CLASSIFIER_DEVICE)
 
+    # V4.2.2: 统一半精度推理结果
+    with torch.inference_mode():
+        if getattr(model, "_precision_mode", "fp32") == "fp16":
+            with torch.autocast(
+                device_type=CLASSIFIER_DEVICE.type,
+                dtype=getattr(model, "_amp_dtype", torch.float32)
+            ):
+                output = model(input_tensor)[0]
+        else:
+            output = model(input_tensor)[0]
+
     # 推理
-    with torch.no_grad():
-        output = model(input_tensor)[0]
+    # with torch.no_grad():
+    #     output = model(input_tensor)[0]
 
     # 截取有效类别数（模型输出可能多于实际物种数）
     num_classes = min(10964, output.shape[0])

--- a/birdid/osea_classifier.py
+++ b/birdid/osea_classifier.py
@@ -181,6 +181,16 @@ class OSEAClassifier:
 
         model.to(self.device)
 
+        # V4.2.2: 统一半精度推理规则
+        if self.device.type in ("cuda", "mps"):
+            self._precision_mode = "fp16"
+            self._amp_dtype = torch.float16
+        else:
+            self._precision_mode = "fp32"
+            self._amp_dtype = torch.float32
+        
+        model.eval()
+
         return model
 
     def _load_bird_info(self) -> List[List[str]]:
@@ -233,9 +243,16 @@ class OSEAClassifier:
 
         input_tensor = self.transform(image).unsqueeze(0).to(self.device)
 
-        self.model.eval()
-        with torch.no_grad():
-            output = self.model(input_tensor)[0]
+        # V4.2.2: 统一半精度推理结果
+        with torch.inference_mode():
+            if self._precision_mode == "fp16":
+                with torch.autocast(self.device.type, dtype=self._amp_dtype):
+                    output = self.model(input_tensor)[0]
+            else:
+                output = self.model(input_tensor)[0]
+
+        # with torch.no_grad():
+        #     output = self.model(input_tensor)[0]
 
         output = output[:self.num_classes]
         probs = torch.nn.functional.softmax(output / temperature, dim=0)
@@ -294,10 +311,19 @@ class OSEAClassifier:
         flipped = image.transpose(Image.FLIP_LEFT_RIGHT)
         input2 = self.transform(flipped).unsqueeze(0).to(self.device)
 
-        self.model.eval()
-        with torch.no_grad():
-            output1 = self.model(input1)[0][:self.num_classes]
-            output2 = self.model(input2)[0][:self.num_classes]
+        # V4.2.2: 统一半精度推理结果
+        with torch.inference_mode():
+            if self._precision_mode == "fp16":
+                with torch.autocast(self.device.type, dtype=self._amp_dtype):
+                    output1 = self.model(input1)[0][:self.num_classes]
+                    output2 = self.model(input2)[0][:self.num_classes]
+            else:
+                output1 = self.model(input1)[0][:self.num_classes]
+                output2 = self.model(input2)[0][:self.num_classes]
+
+        # with torch.no_grad():
+        #     output1 = self.model(input1)[0][:self.num_classes]
+        #     output2 = self.model(input2)[0][:self.num_classes]
 
         avg_output = (output1 + output2) / 2
         probs = torch.nn.functional.softmax(avg_output / temperature, dim=0)

--- a/core/flight_detector.py
+++ b/core/flight_detector.py
@@ -119,6 +119,15 @@ class FlightDetector:
             raise RuntimeError(f"加载飞版检测模型失败: {e}")
         
         self.model.to(self.device)
+
+        # V4.2.2：统一半精度推理规则
+        if self.device.type in ("cuda", "mps"):
+            self._precision_mode = "fp16"
+            self._amp_dtype = torch.float16
+        else:
+            self._precision_mode = "fp32"
+            self._amp_dtype = torch.float32
+
         self.model.eval()
         self.model_loaded = True
     
@@ -169,10 +178,18 @@ class FlightDetector:
         # 预处理
         image_tensor = self.transform(pil_image).unsqueeze(0).to(self.device)
         
-        # 推理
-        with torch.no_grad():
-            prob = self.model(image_tensor).item()
-        
+        # # 推理
+        # with torch.no_grad():
+        #     prob = self.model(image_tensor).item()
+
+        # V4.2.2: 统一半精度推理结果
+        with torch.inference_mode():
+            if self._precision_mode == "fp16":
+                with torch.autocast(device_type=self.device.type, dtype=self._amp_dtype):
+                    prob = self.model(image_tensor).item()
+            else:
+                prob = self.model(image_tensor).item()
+
         return FlightResult(
             is_flying=prob > threshold,
             confidence=prob
@@ -227,10 +244,18 @@ class FlightDetector:
             
             # 组合为批次
             batch_tensor = torch.stack(batch_tensors).to(self.device)
+
+            # V4.2.2: 统一半精度推理结果
+            with torch.inference_mode():
+                if self._precision_mode == "fp16":
+                    with torch.autocast(device_type=self.device.type, dtype=self._amp_dtype):
+                        probs = self.model(batch_tensor).squeeze().cpu().numpy()
+                else:
+                    probs = self.model(batch_tensor).squeeze().cpu().numpy()
             
             # 推理
-            with torch.no_grad():
-                probs = self.model(batch_tensor).squeeze().cpu().numpy()
+            # with torch.no_grad():
+            #     probs = self.model(batch_tensor).squeeze().cpu().numpy()
             
             # 处理单个元素的情况
             if probs.ndim == 0:

--- a/core/keypoint_detector.py
+++ b/core/keypoint_detector.py
@@ -119,14 +119,24 @@ class KeypointDetector:
             self.model.load_state_dict(checkpoint)
             
         self.model.to(self.device)
-        
-        # V4.0.5: 启用 FP16 半精度推理，提速约 30-50%
-        # MPS 和 CUDA 都支持 FP16
-        if self.device.type in ('mps', 'cuda'):
+
+        # V4.2.2：统一半精度推理规则
+        if self.device.type in("cuda", "mps"):
+            self._precision_mode = "fp16"
+            self._amp_dtype = torch.float16
+            # 先统一使用全量半精度推理，保持和原来推理一致
             self.model = self.model.half()
-            self._use_fp16 = True
         else:
-            self._use_fp16 = False
+            self._precision_mode = "fp32"
+            self._amp_dtype = torch.float32
+        
+        # # V4.0.5: 启用 FP16 半精度推理，提速约 30-50%
+        # # MPS 和 CUDA 都支持 FP16
+        # if self.device.type in ('mps', 'cuda'):
+        #     self.model = self.model.half()
+        #     self._use_fp16 = True
+        # else:
+        #     self._use_fp16 = False
             
         self.model.eval()
     
@@ -151,13 +161,24 @@ class KeypointDetector:
         # 转换为PIL并进行推理
         pil_crop = Image.fromarray(bird_crop)
         tensor = self.transform(pil_crop).unsqueeze(0).to(self.device)
-        
-        # V4.0.5: 使用 FP16 和 inference_mode 优化推理
-        if hasattr(self, '_use_fp16') and self._use_fp16:
-            tensor = tensor.half()
-        
+
+        # V4.2.2: 统一半精度推理结果
         with torch.inference_mode():
-            coords, vis = self.model(tensor)
+            if self._precision_mode == "fp16":
+                # 先统一使用全量半精度推理，保持和原来推理一致
+                tensor = tensor.half()
+                coords, vis = self.model(tensor)
+                # with torch.autocast(self.device.type, dtype=self._amp_dtype):
+                #     coords, vis = self.model(tensor)
+            else:
+                coords, vis = self.model(tensor)
+
+        # # V4.0.5: 使用 FP16 和 inference_mode 优化推理
+        # if hasattr(self, '_use_fp16') and self._use_fp16:
+        #     tensor = tensor.half()
+        
+        # with torch.inference_mode():
+        #     coords, vis = self.model(tensor)
         
         coords = coords[0].cpu().numpy()
         vis = vis[0].cpu().numpy()
@@ -243,7 +264,8 @@ class KeypointDetector:
             eye = left_eye if left_eye_vis >= right_eye_vis else right_eye
             eye_px = (int(eye[0] * w), int(eye[1] * h))
             beak_px = (int(beak[0] * w), int(beak[1] * h))
-            if beak_vis >= self.VISIBILITY_THRESHOLD:
+            # if beak_vis >= self.VISIBILITY_THRESHOLD:
+            if beak_visible: # 上面一行应该是之前代码遗漏未修改导致变量未定义
                 radius = int(self._distance(eye_px, beak_px) * self.RADIUS_MULTIPLIER)
             elif box is not None:
                 box_size = max(box[2], box[3])

--- a/iqa_scorer.py
+++ b/iqa_scorer.py
@@ -57,13 +57,23 @@ class IQAScorer:
                 self._topiq_model = CFANet()
                 load_topiq_weights(self._topiq_model, weight_path, self.device)
                 self._topiq_model.to(self.device)
-                
-                # V4.0.5: 启用 FP16 半精度推理，提速约 30-50%
-                if self.device.type in ('mps', 'cuda'):
+
+                # V4.2.2：统一半精度推理规则
+                if self.device.type in("cuda", "mps"):
+                    self._precision_mode = "fp16"
+                    self._amp_dtype = torch.float16
+                    # 先保持该模型强制全量半精度推理，和原来一致。
                     self._topiq_model = self._topiq_model.half()
-                    self._use_fp16 = True
                 else:
-                    self._use_fp16 = False
+                    self._precision_mode = "fp32"
+                    self._amp_dtype = torch.float32
+                
+                # # V4.0.5: 启用 FP16 半精度推理，提速约 30-50%
+                # if self.device.type in ('mps', 'cuda'):
+                #     self._topiq_model = self._topiq_model.half()
+                #     self._use_fp16 = True
+                # else:
+                #     self._use_fp16 = False
                     
                 self._topiq_model.eval()
                 print("✅ TOPIQ 模型加载完成")
@@ -109,14 +119,25 @@ class IQAScorer:
             
             # 转为张量（复用实例变量）
             img_tensor = self._transform(img).unsqueeze(0).to(self.device)
-            
-            # V4.0.5: 使用 FP16 和 inference_mode 优化推理
-            if hasattr(self, '_use_fp16') and self._use_fp16:
-                img_tensor = img_tensor.half()
 
-            # 计算评分
+            #  V4.2.2: 统一半精度推理结果
             with torch.inference_mode():
-                score = topiq_model(img_tensor, return_mos=True)
+                if self._precision_mode == "fp16":
+                    # 先保持该模型强制全量半精度推理，和原来一致。
+                    img_tensor = img_tensor.half()
+                    score = topiq_model(img_tensor, return_mos=True)
+                    # with torch.autocast(self.device.type, dtype=self._amp_dtype):
+                    #     score = topiq_model(img_tensor, return_mos=True)
+                else:
+                    score = topiq_model(img_tensor, return_mos=True)
+            
+            # # V4.0.5: 使用 FP16 和 inference_mode 优化推理
+            # if hasattr(self, '_use_fp16') and self._use_fp16:
+            #     img_tensor = img_tensor.half()
+
+            # # 计算评分
+            # with torch.inference_mode():
+            #     score = topiq_model(img_tensor, return_mos=True)
 
             # 转换为 Python float
             if isinstance(score, torch.Tensor):
@@ -160,13 +181,24 @@ class IQAScorer:
             # 转为张量（复用实例变量）
             img_tensor = self._transform(img).unsqueeze(0).to(self.device)
 
-            # FP16 推理
-            if hasattr(self, '_use_fp16') and self._use_fp16:
-                img_tensor = img_tensor.half()
-
-            # 计算评分
+            # V4.2.2: 统一半精度推理结果
             with torch.inference_mode():
-                score = topiq_model(img_tensor, return_mos=True)
+                if self._precision_mode == "fp16":
+                    # 先保持该模型强制全量半精度推理，和原来一致。
+                    img_tensor = img_tensor.half()
+                    score = topiq_model(img_tensor, return_mos=True)
+                    # with torch.autocast(device_type=self.device.type, dtype=self._amp_dtype):
+                    #     score = topiq_model(img_tensor, return_mos=True)
+                else:
+                    score = topiq_model(img_tensor, return_mos=True)
+
+            # # FP16 推理
+            # if hasattr(self, '_use_fp16') and self._use_fp16:
+            #     img_tensor = img_tensor.half()
+
+            # # 计算评分
+            # with torch.inference_mode():
+            #     score = topiq_model(img_tensor, return_mos=True)
 
             if isinstance(score, torch.Tensor):
                 score = score.item()

--- a/topiq_model.py
+++ b/topiq_model.py
@@ -519,6 +519,15 @@ class TOPIQScorer:
             self._model = CFANet()
             load_topiq_weights(self._model, weight_path, self.device)
             self._model.to(self.device)
+
+            # V4.2.2：统一半精度推理规则
+            if self.device.type in("cuda", "mps"):
+                self._precision_mode = "fp16"
+                self._amp_dtype = torch.float16
+            else:
+                self._precision_mode = "fp32"
+                self._amp_dtype = torch.float32
+
             self._model.eval()
             
         return self._model
@@ -550,10 +559,18 @@ class TOPIQScorer:
             
             transform = T.ToTensor()
             img_tensor = transform(img).unsqueeze(0).to(self.device)
+
+            # V4.2.2: 统一半精度推理结果
+            with torch.inference_mode():
+                if self._precision_mode == "fp16":
+                    with torch.autocast(self.device.type, dtype=self._amp_dtype):
+                        score = model(img_tensor, return_mos=True)
+                else:
+                    score = model(img_tensor, return_mos=True)
             
-            # 计算评分
-            with torch.no_grad():
-                score = model(img_tensor, return_mos=True)
+            # # 计算评分
+            # with torch.no_grad():
+            #     score = model(img_tensor, return_mos=True)
             
             if isinstance(score, torch.Tensor):
                 score = score.item()


### PR DESCRIPTION
### 1. Overview
This PR aims to standardize the initialization and inference workflows across multiple models. Previously, half-precision implementations varied between models; these have now been migrated to the officially recommended `torch.autocast()` approach to enhance code consistency and readability.

### 2. Key Changes
**Format Standardization:** Refactored the initialization and inference steps for multiple models to ensure they follow a unified calling template.

**Automatic Operator Conversion:** For most models, manual type conversions (such as `.half()` or `.float16()`) have been removed in favor of `torch.autocast(device_type='cuda', dtype=torch.float16)` for automatic mixed-precision management.

**Exceptions:** The **keypoint** and **iqa** models maintain full-pipeline half-precision inference after the transition to ensure specific performance requirements are met.

**Model Coverage:** This update applies to the following models: `yolo`, `osea`, `flight`, `keypoint`, and `iqa`.

### 3. Impact & Verification
**Compatibility:** By unifying the interface, all future model integrations can directly reuse this standardized pattern.

**Performance Testing:** Preliminary benchmarks indicate that inference speed and VRAM utilization remain stable, with numerical accuracy aligning with expected results.