### PR TITLE
Add completion sound setting

### DIFF
--- a/advanced_config.py
+++ b/advanced_config.py
@@ -65,6 +65,7 @@ class AdvancedConfig:
         
         # 临时文件管理 V4.1
         "keep_temp_files": True,        # 保留临时预览图片（统一控制 tmp JPG + debug crops）
+        "completion_sound_enabled": True,  # 处理完成提示音 / Completion sound after processing
 
         # 鸟种英文名显示格式 V4.x (AviList mapping)
         #   "default"    = OSEA model original names
@@ -345,6 +346,13 @@ class AdvancedConfig:
 
     def set_keep_temp_files(self, value):
         self.config["keep_temp_files"] = bool(value)
+
+    @property
+    def completion_sound_enabled(self) -> bool:
+        return self.config.get("completion_sound_enabled", True)
+
+    def set_completion_sound_enabled(self, value: bool):
+        self.config["completion_sound_enabled"] = bool(value)
 
     # V4.x: 鸟种英文名显示格式
     @property

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -647,6 +647,8 @@
     "preview_management": "Preview Management",
     "keep_preview": "Keep preview images",
     "keep_preview_hint": "Retain AI crop previews and temp files (cache/debug_crops)",
+    "completion_sound": "Play completion sound",
+    "completion_sound_hint": "Play a short sound when photo processing finishes",
     "auto_cleanup": "Auto cleanup period",
     "cleanup_3_days": "3 days",
     "cleanup_7_days": "7 days",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -647,6 +647,8 @@
     "preview_management": "预览图管理",
     "keep_preview": "保留预览图片",
     "keep_preview_hint": "保留 AI 分析裁切图和临时预览（cache/debug_crops 目录）",
+    "completion_sound": "播放完成提示音",
+    "completion_sound_hint": "照片处理完成后播放一段简短提示音",
     "auto_cleanup": "自动清理周期",
     "cleanup_3_days": "3 天",
     "cleanup_7_days": "7 天",

--- a/ui/advanced_settings_dialog.py
+++ b/ui/advanced_settings_dialog.py
@@ -460,6 +460,18 @@ class AdvancedSettingsDialog(QDialog):
         """)
         preview_layout.addWidget(keep_preview_hint)
 
+        completion_sound_check = QCheckBox(self.i18n.t("advanced_settings.completion_sound"))
+        self.vars["completion_sound_enabled"] = completion_sound_check
+        preview_layout.addWidget(completion_sound_check)
+
+        completion_sound_hint = QLabel(self.i18n.t("advanced_settings.completion_sound_hint"))
+        completion_sound_hint.setStyleSheet(f"""
+            color: {COLORS['text_muted']};
+            font-size: 11px;
+            margin-left: 24px;
+        """)
+        preview_layout.addWidget(completion_sound_hint)
+
         # 说明：不保留预览图时，选鸟完成后自动打开 Finder 显示结果目录
 
         layout.addWidget(preview_group_widget)
@@ -614,6 +626,9 @@ class AdvancedSettingsDialog(QDialog):
         # 加载预览图设置
         keep_temp = self.config.keep_temp_files
         self.vars["keep_temp_files"].setChecked(keep_temp)
+        self.vars["completion_sound_enabled"].setChecked(
+            self.config.completion_sound_enabled
+        )
         
 
 
@@ -670,6 +685,9 @@ class AdvancedSettingsDialog(QDialog):
 
         # 保存预览图设置
         self.config.set_keep_temp_files(self.vars["keep_temp_files"].isChecked())
+        self.config.set_completion_sound_enabled(
+            self.vars["completion_sound_enabled"].isChecked()
+        )
 
         # 保存外部应用列表
         self.config.set_external_apps(self._apps_data)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -2721,6 +2721,11 @@ class SuperPickyMainWindow(QMainWindow):
 
     def _play_completion_sound(self):
         """播放完成音效"""
+        from advanced_config import get_advanced_config
+
+        if not get_advanced_config().completion_sound_enabled:
+            return
+
         sound_path = os.path.join(
             os.path.dirname(__file__), "..",
             "img", "toy-story-short-happy-audio-logo-short-cartoony-intro-outro-music-125627.mp3"


### PR DESCRIPTION
## Summary
- Add a persisted setting to enable or disable the completion sound
- Add the checkbox to Output settings with English and Chinese labels
- Skip completion sound playback when the setting is disabled

## Verification
- python3 -m py_compile advanced_config.py ui/advanced_settings_dialog.py ui/main_window.py
- python3 -m json.tool locales/en_US.json
- python3 -m json.tool locales/zh_CN.json

Co-authored-by: Codex AI <codex-ai@users.noreply.github.com>