### PR TITLE
perf: reduce repeated image decode and debug I/O

### DIFF
--- a/ai_model.py
+++ b/ai_model.py
@@ -3,6 +3,7 @@ import time
 import cv2
 import numpy as np
 from ultralytics import YOLO
+from typing import Optional
 from tools.utils import log_message
 from config import config, get_lazy_registry
 # V3.2: 移除未使用的 sharpness 计算器导入
@@ -52,16 +53,36 @@ def load_yolo_model(log_callback=None):
     return model
 
 
-def preprocess_image(image_path, target_size=None):
-    """预处理图像"""
+def read_image_bgr(image_path: str) -> Optional[np.ndarray]:
+    """以 BGR 格式读取图像，兼容 Windows 中文路径。"""
+    try:
+        data = np.fromfile(image_path, dtype=np.uint8)
+        if data.size == 0:
+            return None
+        return cv2.imdecode(data, cv2.IMREAD_COLOR)
+    except Exception:
+        return None
+
+
+def preprocess_image(
+    image_path: str,
+    target_size: Optional[int] = None,
+    source_image: Optional[np.ndarray] = None,
+) -> Optional[np.ndarray]:
+    """预处理图像，允许复用上游已解码的 BGR 图像。"""
     if target_size is None:
         target_size = config.ai.TARGET_IMAGE_SIZE
-    
-    img = cv2.imread(image_path)
+
+    img = source_image if source_image is not None else read_image_bgr(image_path)
+    if img is None:
+        return None
+
     h, w = img.shape[:2]
     scale = target_size / max(w, h)
-    img = cv2.resize(img, (int(w * scale), int(h * scale)), interpolation=cv2.INTER_AREA)
-    return img
+    new_size = (int(w * scale), int(h * scale))
+    if new_size == (w, h):
+        return img.copy()
+    return cv2.resize(img, new_size, interpolation=cv2.INTER_AREA)
 
 
 # V3.2: 移除 _get_sharpness_calculator（锐度现在由 keypoint_detector 计算）
@@ -74,7 +95,18 @@ def _get_iqa_scorer():
     return registry.get_or_create(key, lambda: get_iqa_scorer(device=get_best_device().type))
 
 
-def detect_and_draw_birds(image_path, model, output_path, dir, ui_settings, i18n=None, skip_nima=False, focus_point=None, report_db=None):
+def detect_and_draw_birds(
+    image_path,
+    model,
+    output_path,
+    dir,
+    ui_settings,
+    i18n=None,
+    skip_nima=False,
+    focus_point=None,
+    report_db=None,
+    decoded_image: Optional[np.ndarray] = None,
+):
     """
     检测并标记鸟类（V4.2 - 支持多鸟对焦点选择）
 
@@ -87,6 +119,7 @@ def detect_and_draw_birds(image_path, model, output_path, dir, ui_settings, i18n
         i18n: I18n instance for internationalization (optional)
         skip_nima: 如果为True，跳过NIMA计算（用于双眼不可见的情况）
         focus_point: 对焦点坐标 (x, y)，归一化 0-1，用于多鸟时选择对焦的鸟
+        decoded_image: 复用上游已解码的 BGR 图像，减少重复 JPEG 解码
     
     Returns:
         元组 (found_bird, bird_result, confidence, sharpness, nima_score, bird_bbox, img_dims, bird_mask, bird_count)
@@ -121,7 +154,10 @@ def detect_and_draw_birds(image_path, model, output_path, dir, ui_settings, i18n
 
     # Step 1: 图像预处理
     step_start = time.time()
-    image = preprocess_image(image_path)
+    image = preprocess_image(image_path, source_image=decoded_image)
+    if image is None:
+        log_message(f"ERROR: cannot decode image {image_path}", dir)
+        return None
     height, width, _ = image.shape
     preprocess_time = (time.time() - step_start) * 1000
     # V3.3: 简化日志，移除步骤详情
@@ -419,8 +455,7 @@ def detect_and_draw_birds(image_path, model, output_path, dir, ui_settings, i18n
         try:
             # Mask is already resized to image size by ultralytics by default in modern versions
             # But let's verify if we need to resize
-            # results[0].masks.data is a torch tensor on GPU/CPU
-            raw_mask = results[0].masks.data[bird_idx].cpu().numpy()
+            raw_mask = masks[bird_idx]
             
             # Ensure mask is same size as processed image (width, height)
             if raw_mask.shape != (height, width):

--- a/core/keypoint_detector.py
+++ b/core/keypoint_detector.py
@@ -319,26 +319,31 @@ class KeypointDetector:
         V3.7 改动: 使用 Tenengrad (Sobel梯度) 替代 Laplacian以减少噪点干扰
         并使用对数归一化将结果映射到 0-1000 范围
         """
-        if mask.sum() == 0:
+        if image is None or mask is None:
             return 0.0
-        
-        # 转灰度
-        if len(image.shape) == 3:
-            gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+
+        mask_u8 = mask.astype(np.uint8, copy=False)
+        if cv2.countNonZero(mask_u8) == 0:
+            return 0.0
+
+        x, y, width, height = cv2.boundingRect(mask_u8)
+        if width <= 0 or height <= 0:
+            return 0.0
+
+        roi = image[y:y + height, x:x + width]
+        roi_mask = mask_u8[y:y + height, x:x + width]
+        if cv2.countNonZero(roi_mask) == 0:
+            return 0.0
+
+        if len(roi.shape) == 3:
+            gray = cv2.cvtColor(roi, cv2.COLOR_RGB2GRAY)
         else:
-            gray = image
-        
-        # Tenengrad 算子 (Sobel梯度平方和)
-        gx = cv2.Sobel(gray, cv2.CV_64F, 1, 0, ksize=3)
-        gy = cv2.Sobel(gray, cv2.CV_64F, 0, 1, ksize=3)
-        gradient_magnitude = gx ** 2 + gy ** 2
-        
-        # 只取掩码区域的平均值
-        mask_pixels = mask > 0
-        if mask_pixels.sum() == 0:
-            return 0.0
-            
-        raw_sharpness = float(gradient_magnitude[mask_pixels].mean())
+            gray = roi
+
+        gx = cv2.Sobel(gray, cv2.CV_32F, 1, 0, ksize=3)
+        gy = cv2.Sobel(gray, cv2.CV_32F, 0, 1, ksize=3)
+        gradient_magnitude = cv2.add(cv2.multiply(gx, gx), cv2.multiply(gy, gy))
+        raw_sharpness = float(cv2.mean(gradient_magnitude, mask=roi_mask)[0])
         
         # 对数归一化到 0-1000
         # V4.0 修复: 降低 MIN_VAL，之前 1460 太高导致锐利照片也返回 0

--- a/core/photo_processor.py
+++ b/core/photo_processor.py
@@ -31,7 +31,7 @@ from datetime import datetime
 
 # 现有模块
 from tools.find_bird_util import raw_to_jpeg
-from ai_model import load_yolo_model, detect_and_draw_birds
+from ai_model import load_yolo_model, detect_and_draw_birds, read_image_bgr
 from tools.report_db import ReportDB
 from tools.exiftool_manager import get_exiftool_manager
 from tools.file_utils import ensure_hidden_directory, clear_readonly_attribute
@@ -1336,13 +1336,18 @@ class PhotoProcessor:
                 'can_read_focus_raw': in_can_read_focus_raw,
             }
         
-        def run_yolo_detection(in_filepath: str, focus_point: Optional[Tuple[float, float]] = None):
+        def run_yolo_detection(
+            in_filepath: str,
+            focus_point: Optional[Tuple[float, float]] = None,
+            decoded_image: Optional[np.ndarray] = None,
+        ):
             # 单模型实例在”预取线程 + 主线程复选”两处复用，串行化推理调用以保证稳定性
             with yolo_infer_lock:
                 return detect_and_draw_birds(
                     in_filepath, _yolo_model_box[0], None, self.dir_path, ui_settings, None,
                     skip_nima=True, focus_point=focus_point,
-                    report_db=self.report_db
+                    report_db=self.report_db,
+                    decoded_image=decoded_image,
                 )
         
         def read_focus_result_safe(in_raw_path: Optional[str]):
@@ -1448,10 +1453,11 @@ class PhotoProcessor:
             in_filepath = ctx['filepath']
             
             yolo_start = time.time()
+            decoded_image = read_image_bgr(in_filepath)
             yolo_result = None
             yolo_error = None
             try:
-                yolo_result = run_yolo_detection(in_filepath, None)
+                yolo_result = run_yolo_detection(in_filepath, None, decoded_image)
                 if yolo_result is None:
                     yolo_error = self.i18n.t("logs.cannot_process", filename=in_filename)
             except Exception as e:
@@ -1466,6 +1472,7 @@ class PhotoProcessor:
                 'raw_ext': ctx['raw_ext'],
                 'raw_path': ctx['raw_path'],
                 'can_read_focus_raw': ctx['can_read_focus_raw'],
+                'decoded_image': decoded_image,
                 'result': yolo_result,
                 'error': yolo_error,
                 'yolo_ms': (time.time() - yolo_start) * 1000,
@@ -1690,8 +1697,6 @@ class PhotoProcessor:
                  # RAW+JPG 配对照片或纯 JPG：直接将 JPG 路径写入 temp_jpeg_path
                  path_update_data['temp_jpeg_path'] = os.path.relpath(yolo_item['filepath'], self.dir_path)
                  
-            if path_update_data and self.report_db:
-                 self.report_db.update_photo(original_prefix, path_update_data)
             raw_ext = yolo_item['raw_ext']
             raw_path = yolo_item['raw_path']
             can_read_focus_raw = yolo_item['can_read_focus_raw']
@@ -1771,7 +1776,11 @@ class PhotoProcessor:
                 if focus_point_for_selection is not None:
                     refine_start = time.time()
                     try:
-                        refined_result = run_yolo_detection(filepath, focus_point_for_selection)
+                        refined_result = run_yolo_detection(
+                            filepath,
+                            focus_point_for_selection,
+                            yolo_item.get('decoded_image'),
+                        )
                         if refined_result is not None:
                             detected, _, confidence, sharpness, _, bird_bbox, img_dims, bird_mask, bird_count = refined_result
                     except Exception:
@@ -1806,6 +1815,9 @@ class PhotoProcessor:
                 
                 # 记录评分（用于文件移动）- V4.0.4: 使用 original_prefix 确保匹配 NEF
                 self.file_ratings[original_prefix] = rating_value
+
+                if path_update_data and self.report_db:
+                    self.report_db.update_photo(original_prefix, path_update_data)
 
                 if detail_metadata_for_rejected and self.report_db:
                     rejected_detail = {
@@ -1844,11 +1856,10 @@ class PhotoProcessor:
 
                 # 即使置信度不足，只要检测到鸟就生成 crop_debug 供浏览预览
                 # (yolo_debug_path 已由 ai_model.py 写入 DB，crop_debug 同步生成保持一致)
-                if detected and bird_bbox is not None and img_dims is not None:
+                should_build_debug = bool(self.callbacks.crop_preview or self.settings.save_crop)
+                if detected and should_build_debug and bird_bbox is not None and img_dims is not None:
                     try:
-                        import cv2 as _cv2_early
-                        # _orig = _cv2_early.imread(filepath)
-                        _orig = _cv2_early.imdecode(np.fromfile(filepath, dtype=np.uint8), _cv2_early.IMREAD_COLOR)
+                        _orig = yolo_item.get('decoded_image')
                         if _orig is not None:
                             _h, _w = _orig.shape[:2]
                             _sw, _sh = img_dims
@@ -1860,7 +1871,13 @@ class PhotoProcessor:
                             _oh = int(min(_bh * _sy, _h - _oy))
                             _crop = _orig[_oy:_oy + _oh, _ox:_ox + _ow]
                             if _crop.size > 0:
-                                self._save_debug_crop(filename, _crop)
+                                debug_img = self._save_debug_crop(
+                                    filename,
+                                    _crop,
+                                    write_file=self.settings.save_crop,
+                                )
+                                if debug_img is not None and self.callbacks.crop_preview:
+                                    self.callbacks.crop_preview(debug_img, None)
                     except Exception:
                         pass
 
@@ -1897,8 +1914,9 @@ class PhotoProcessor:
             if use_keypoints and detected and bird_bbox is not None and img_dims is not None:
                 try:
                     import cv2
-                    # orig_img = cv2.imread(filepath)  # 只读取一次!
-                    orig_img = cv2.imdecode(np.fromfile(filepath, dtype=np.uint8), cv2.IMREAD_COLOR)
+                    orig_img = yolo_item.get('decoded_image')
+                    if orig_img is None:
+                        orig_img = read_image_bgr(filepath)
                     if orig_img is not None:
                         h_orig, w_orig = orig_img.shape[:2]
                         # 获取YOLO处理时的图像尺寸
@@ -2274,7 +2292,8 @@ class PhotoProcessor:
                     focus_status_en = "WORST"
             
             # V3.9: 生成调试可视化图（仅对有鸟的照片）
-            if detected and bird_crop_bgr is not None:
+            should_build_debug = bool(self.callbacks.crop_preview or self.settings.save_crop)
+            if detected and should_build_debug and bird_crop_bgr is not None:
                 # 计算裁剪区域内的坐标
                 head_center_crop = None
                 if head_center_orig is not None:
@@ -2317,7 +2336,8 @@ class PhotoProcessor:
                         head_center_crop,
                         head_radius_val,
                         focus_point_crop,
-                        focus_status_en  # 使用英文标签
+                        focus_status_en,  # 使用英文标签
+                        write_file=self.settings.save_crop,
                     )
                     # V4.2: 发送裁剪预览到 UI（同时传对焦状态供 dock 显示）
                     if debug_img is not None and self.callbacks.crop_preview:
@@ -2503,6 +2523,7 @@ class PhotoProcessor:
                     adj_topiq_csv,  # V4.1: 调整后美学
                     prefetched_exif,  # V2: EXIF 元数据
                     caption,  # V4.1: 评分说明
+                    path_update_data,  # 合并路径字段，减少一次 DB update
                 )
                 add_photo_stage('csv_update', (time.time() - csv_update_start) * 1000)
                 
@@ -2756,7 +2777,8 @@ class PhotoProcessor:
         head_center_crop: tuple = None,
         head_radius: int = None,
         focus_point_crop: tuple = None,
-        focus_status: str = None
+        focus_status: str = None,
+        write_file: bool = True,
     ):
         """
         V3.9: 保存调试可视化图片到 .superpicky/debug_crops/ 目录
@@ -2767,11 +2789,6 @@ class PhotoProcessor:
         - 🔴 红色十字: 对焦点位置
         """
         import cv2
-        
-        # 创建调试目录（Windows 下自动隐藏）
-        debug_dir = os.path.join(self.dir_path, ".superpicky", "cache", "crop_debug")
-        ensure_hidden_directory(os.path.join(self.dir_path, ".superpicky"))
-        os.makedirs(debug_dir, exist_ok=True)
         
         # 复制原图
         debug_img = bird_crop_bgr.copy()
@@ -2809,21 +2826,27 @@ class PhotoProcessor:
             cv2.putText(debug_img, focus_status, (10, 30), 
                        cv2.FONT_HERSHEY_SIMPLEX, 0.8, (255, 255, 255), 2)
         
-        # 保存调试图
-        # V4.0.5: filename 可能包含子目录前缀（如 .superpicky/cache/_Z9W1029.jpg），需取 basename
-        file_prefix = os.path.splitext(os.path.basename(filename))[0]
-        debug_path = os.path.join(debug_dir, f"{file_prefix}.jpg")
-        cv2.imwrite(debug_path, debug_img, [cv2.IMWRITE_JPEG_QUALITY, 85])
-        
-        # NOTE: debug_crop_path 由 ai_model.py 的 insert_photo() 统一写入数据库
-        # V4.2: 现在 debug_crop_path 专门指代 crop_debug 图片，此处需要回写数据库
-        if hasattr(self, 'report_db') and self.report_db:
-             try:
-                 rel_path = os.path.relpath(debug_path, self.dir_path)
-                 # 更新数据库中的 debug_crop_path 字段
-                 self.report_db.update_photo(file_prefix, {"debug_crop_path": rel_path})
-             except Exception:
-                 pass
+        if write_file:
+            # 创建调试目录（Windows 下自动隐藏）
+            debug_dir = os.path.join(self.dir_path, ".superpicky", "cache", "crop_debug")
+            ensure_hidden_directory(os.path.join(self.dir_path, ".superpicky"))
+            os.makedirs(debug_dir, exist_ok=True)
+
+            # 保存调试图
+            # V4.0.5: filename 可能包含子目录前缀（如 .superpicky/cache/_Z9W1029.jpg），需取 basename
+            file_prefix = os.path.splitext(os.path.basename(filename))[0]
+            debug_path = os.path.join(debug_dir, f"{file_prefix}.jpg")
+            cv2.imwrite(debug_path, debug_img, [cv2.IMWRITE_JPEG_QUALITY, 85])
+
+            # NOTE: debug_crop_path 由 ai_model.py 的 insert_photo() 统一写入数据库
+            # V4.2: 现在 debug_crop_path 专门指代 crop_debug 图片，此处需要回写数据库
+            if hasattr(self, 'report_db') and self.report_db:
+                try:
+                    rel_path = os.path.relpath(debug_path, self.dir_path)
+                    # 更新数据库中的 debug_crop_path 字段
+                    self.report_db.update_photo(file_prefix, {"debug_crop_path": rel_path})
+                except Exception:
+                    pass
         
         # V4.2: 返回标注后的图像，用于 UI 实时预览
         return debug_img
@@ -2874,6 +2897,7 @@ class PhotoProcessor:
             adj_topiq: float = None,  # V4.1: 调整后美学
             exif_data: dict = None,  # V2: EXIF 元数据
             caption: str = None,  # V4.1: 评分说明
+            extra_data: Optional[Dict] = None,
     ):
         """更新报告数据库中的关键点数据和评分（SQLite 版本）"""
         if self.report_db is None:
@@ -2898,6 +2922,9 @@ class PhotoProcessor:
         # V2: 合并 EXIF 元数据（先合并，再覆盖 caption，避免 exif_data 里的空值覆盖评分说明）
         if exif_data:
             data.update(exif_data)
+
+        if extra_data:
+            data.update(extra_data)
 
         # caption 最后写入，确保不被 exif_data 里的空 Caption-Abstract 覆盖
         if caption is not None:


### PR DESCRIPTION
## Summary
- reuse one decoded BGR image across YOLO preprocess, multi-bird refine, keypoint crop, and early debug crop generation
- limit sharpness Sobel work to the head-mask bounding box instead of the whole crop
- avoid writing crop debug files when only UI preview is needed, while keeping existing save behavior unchanged
- keep YOLO mask behavior unchanged, but stop re-reading esults[0].masks.data after masks were already materialized to NumPy

## Review notes
- migrated onto the latest dev before opening this PR
- intentionally did not include temporary test directories such as 	est_raw
- intentionally kept save_crop default behavior unchanged

## Validation
- python -m py_compile ai_model.py core/keypoint_detector.py core/photo_processor.py
