### PR TITLE
Add burst grouping preference

### DIFF
--- a/advanced_config.py
+++ b/advanced_config.py
@@ -31,6 +31,7 @@ class AdvancedConfig:
         "exposure_threshold": 0.10,  # 曝光阈值 (0.05-0.20) - 过曝/欠曝像素占比超过此值将降级一星
         
         # 连拍检测设置 V4.0.4
+        "burst_enabled": True,  # 启用连拍分组；关闭后跳过连拍检测与合并 / Enable burst grouping; skip detection and merge when off
         "burst_fps": 10,  # 连拍速度 (4-20张/秒) - 拍摄速度快于此值视为连拍
         "burst_min_count": 4,         # 连拍最少张数 (3-10) - 至少此数量连续照片才算连拍组
         
@@ -221,6 +222,11 @@ class AdvancedConfig:
         return self.config.get("exposure_threshold", 0.10)
     
     @property
+    def burst_enabled(self):
+        """是否启用连拍分组 / Return whether burst grouping is enabled."""
+        return bool(self.config.get("burst_enabled", True))
+
+    @property
     def burst_fps(self):
         """连拍速度 (4-20张/秒)"""
         return self.config.get("burst_fps", 10)
@@ -273,7 +279,11 @@ class AdvancedConfig:
     def set_exposure_threshold(self, value):
         """设置曝光阈值 (0.05-0.20)"""
         self.config["exposure_threshold"] = max(0.05, min(0.20, float(value)))
-    
+
+    def set_burst_enabled(self, value):
+        """设置是否启用连拍分组 / Save whether burst grouping is enabled."""
+        self.config["burst_enabled"] = bool(value)
+
     def set_burst_fps(self, value):
         """设置连拍速度 (4-20张/秒)"""
         self.config["burst_fps"] = max(4, min(20, int(value)))

--- a/core/photo_processor.py
+++ b/core/photo_processor.py
@@ -502,6 +502,7 @@ class PhotoProcessor:
         exiftool_session_opened = False
         advanced_config = get_advanced_config()
         metadata_write_mode = str(advanced_config.get_metadata_write_mode()).strip().lower()
+        detect_burst = self.settings.detect_burst and advanced_config.burst_enabled
 
         try:
             if metadata_write_mode != "none":
@@ -513,7 +514,7 @@ class PhotoProcessor:
             raw_dict, jpg_dict, files_tbr = self._scan_files()
             
             # 阶段1.5: V4.0.4 早期连拍检测（只基于时间戳）
-            if self.settings.detect_burst:
+            if detect_burst:
                 self.burst_map = self._detect_bursts_early(raw_dict)
             
             # 阶段2: RAW转换
@@ -551,7 +552,7 @@ class PhotoProcessor:
                 self._move_files_to_rating_folders(raw_dict)
             
             # 阶段6: V4.0.4 跨目录连拍合并（在文件整理完成后）
-            if self.settings.detect_burst and self.burst_map and organize_files:
+            if detect_burst and self.burst_map and organize_files:
                 burst_stats = self._consolidate_burst_groups(raw_dict)
                 self.stats['burst_groups'] = burst_stats.get('groups', 0)
                 self.stats['burst_moved'] = burst_stats.get('moved', 0)

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -618,6 +618,8 @@
     "birdid_confidence": "ID Confidence",
     "birdid_confidence_hint": "Higher = More accurate, but may miss some species",
     "section_burst": "Burst Detection",
+    "burst_enabled": "Enable Burst Grouping",
+    "burst_enabled_hint": "When disabled, continuous shots are not grouped or moved into burst folders",
     "section_xmp": "XMP Write",
     "xmp_write": "XMP Sidecar Write",
     "xmp_write_hint": "When checked: write XMP sidecar only, do not modify RAW; when unchecked: write directly to ARW",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -618,6 +618,8 @@
     "birdid_confidence": "识别确信度",
     "birdid_confidence_hint": "越高越准确，但可能识别不出一些鸟种",
     "section_burst": "连拍设置",
+    "burst_enabled": "启用连拍分组",
+    "burst_enabled_hint": "关闭后不会把连续拍摄的照片分组，也不会移动到 burst 文件夹",
     "section_xmp": "XMP 写入",
     "xmp_write": "XMP 侧车写入",
     "xmp_write_hint": "勾选时只写 XMP 侧车文件，不修改原 RAW；不勾选时直接写入 ARW",

--- a/ui/advanced_settings_dialog.py
+++ b/ui/advanced_settings_dialog.py
@@ -223,6 +223,18 @@ class AdvancedSettingsDialog(QDialog):
         # 分隔线
         self._add_divider(layout)
 
+        burst_enabled = QCheckBox(self.i18n.t("advanced_settings.burst_enabled"))
+        self.vars["burst_enabled"] = burst_enabled
+        layout.addWidget(burst_enabled)
+
+        burst_enabled_hint = QLabel(self.i18n.t("advanced_settings.burst_enabled_hint"))
+        burst_enabled_hint.setStyleSheet(f"""
+            color: {COLORS['text_muted']};
+            font-size: 11px;
+            margin-left: 24px;
+        """)
+        layout.addWidget(burst_enabled_hint)
+
         # 连拍速度
         self.vars["burst_fps"] = self._create_slider_setting(
             layout,
@@ -232,6 +244,7 @@ class AdvancedSettingsDialog(QDialog):
             step=1,
             format_func=lambda v: f"{v} fps"
         )
+        burst_enabled.toggled.connect(self.vars["burst_fps"].setEnabled)
 
         layout.addStretch()
         return page
@@ -622,6 +635,8 @@ class AdvancedSettingsDialog(QDialog):
         self.vars["min_confidence"].setValue(int(self.config.min_confidence * 100))
         self.vars["min_sharpness"].setValue(int(self.config.min_sharpness))
         self.vars["min_nima"].setValue(int(self.config.min_nima * 10))
+        self.vars["burst_enabled"].setChecked(self.config.burst_enabled)
+        self.vars["burst_fps"].setEnabled(self.config.burst_enabled)
         self.vars["burst_fps"].setValue(int(self.config.burst_fps))
         self.vars["birdid_confidence"].setValue(int(self.config.birdid_confidence))
 
@@ -703,12 +718,14 @@ class AdvancedSettingsDialog(QDialog):
         min_confidence = self.vars["min_confidence"].value() / 100.0
         min_sharpness = self.vars["min_sharpness"].value()
         min_nima = self.vars["min_nima"].value() / 10.0
+        burst_enabled = self.vars["burst_enabled"].isChecked()
         burst_fps = self.vars["burst_fps"].value()
         birdid_confidence = self.vars["birdid_confidence"].value()
 
         self.config.set_min_confidence(min_confidence)
         self.config.set_min_sharpness(min_sharpness)
         self.config.set_min_nima(min_nima)
+        self.config.set_burst_enabled(burst_enabled)
         self.config.set_burst_fps(burst_fps)
         self.config.set_birdid_confidence(birdid_confidence)
 

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -335,6 +335,10 @@ class WorkerThread(threading.Thread):
             birdid_country_code = None
             birdid_region_code = None
 
+        advanced_config = get_advanced_config()
+        burst_requested = self.ui_settings[7] if len(self.ui_settings) > 7 else True
+        detect_burst = bool(burst_requested) and advanced_config.burst_enabled
+
         settings = ProcessingSettings(
             ai_confidence=self.ui_settings[0],
             sharpness_threshold=self.ui_settings[1],
@@ -343,7 +347,7 @@ class WorkerThread(threading.Thread):
             normalization_mode=self.ui_settings[4] if len(self.ui_settings) > 4 else 'log_compression',
             detect_flight=self.ui_settings[5] if len(self.ui_settings) > 5 else True,
             detect_exposure=self.ui_settings[6] if len(self.ui_settings) > 6 else False,  # V3.8: 默认关闭
-            detect_burst=self.ui_settings[7] if len(self.ui_settings) > 7 else True,  # V4.0: 默认开启
+            detect_burst=detect_burst,  # V4.0: 主界面与高级设置共同控制连拍检测 / Main UI and Advanced Settings both gate burst detection
             # BirdID 设置
             auto_identify=birdid_auto_identify,
             birdid_use_ebird=birdid_use_ebird,
@@ -355,7 +359,7 @@ class WorkerThread(threading.Thread):
         # ── 写完整会话头（含所有设置）到日志文件 ────────────────
         from datetime import datetime as _dt
         try:
-            _adv = get_advanced_config()
+            _adv = advanced_config
             _on_off = lambda b: "On" if b else "Off"
             _session_header = "\n".join([
                 "",


### PR DESCRIPTION
## Summary
- add a persisted advanced setting to enable or disable burst grouping
- skip burst detection and burst-folder organization when disabled
- expose the setting in Advanced Settings with localized labels and help text
- combine the existing main-window burst request with the advanced preference

## Verification
- Python compilation passed for all four changed Python modules
- en_US.json and zh_CN.json parsed successfully as UTF-8 JSON
- git diff check passed against upstream/master