### PR TITLE
fix(reset): ignore OS metadata residue during cleanup

### DIFF
--- a/tools/find_bird_util.py
+++ b/tools/find_bird_util.py
@@ -456,6 +456,67 @@ def _is_superpicky_folder(name: str) -> bool:
     return name in _build_superpicky_folder_set()
 
 
+def is_ignorable_reset_residue(filename: str) -> bool:
+    """
+    判断 reset 后是否可以忽略/清理的系统元数据文件。
+
+    参数:
+    filename (str): 文件名，不需要包含完整路径。
+
+    返回:
+    bool: True 表示这是可安全删除的系统元数据残留。
+
+    Determine whether a post-reset file is ignorable OS metadata.
+
+    Parameters:
+    filename (str): File name only; a full path is not required.
+
+    Return:
+    bool: True when the file is safe-to-remove OS metadata residue.
+    """
+    lower_name = filename.lower()
+    return (
+        filename.startswith("._")
+        or lower_name in {".ds_store", "thumbs.db", "desktop.ini"}
+    )
+
+
+def cleanup_ignorable_reset_residue(directory: str) -> int:
+    """
+    递归清理 reset 目录中的系统元数据残留文件。
+
+    参数:
+    directory (str): 需要清理的目录路径。
+
+    返回:
+    int: 成功删除的残留文件数量。
+
+    Recursively remove ignorable OS metadata residue from a reset directory.
+
+    Parameters:
+    directory (str): Directory to clean.
+
+    Return:
+    int: Number of residue files successfully removed.
+    """
+    removed = 0
+    if not os.path.isdir(directory):
+        return removed
+
+    for root, _dirs, files in os.walk(directory):
+        for filename in files:
+            if not is_ignorable_reset_residue(filename):
+                continue
+            path = os.path.join(root, filename)
+            try:
+                if os.path.islink(path) or os.path.isfile(path):
+                    os.remove(path)
+                    removed += 1
+            except OSError:
+                continue
+    return removed
+
+
 def force_flatten_directory(directory, log_callback=None, i18n=None) -> dict:
     """
     高级重置核心：把「SuperPicky 生成的顶层目录」内的文件递归移回 directory 根。

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -2514,14 +2514,27 @@ class SuperPickyMainWindow(QMainWindow):
                 
                 # V3.9: 删除评分目录（所有文件已移走）
                 emit_log(i18n.t("logs.reset_step3"))
+                from tools.find_bird_util import cleanup_ignorable_reset_residue
                 deleted_dirs = 0
                 for rating_dir in rating_dirs:
                     rating_path = os.path.join(directory_path, rating_dir)
                     if os.path.exists(rating_path) and os.path.isdir(rating_path):
+                        # 先清理系统元数据残留，再判断是否仍有真实文件需要保留。
+                        # Remove OS metadata residue first, then preserve any real files that remain.
+                        cleanup_ignorable_reset_residue(rating_path)
                         # V4.3.0: 仅当评分目录内已无任何文件才删除，避免误删残留（数据安全）
-                        if any(fs for _r, _d, fs in os.walk(rating_path)):
+                        residual_files = []
+                        for _r, _d, fs in os.walk(rating_path):
+                            for _filename in fs:
+                                _rel = os.path.relpath(os.path.join(_r, _filename), rating_path)
+                                residual_files.append(_rel)
+                        if residual_files:
+                            sample = ", ".join(residual_files[:3])
+                            if len(residual_files) > 3:
+                                sample = f"{sample}, ..."
                             emit_log(i18n.t("logs.empty_dir_delete_failed",
-                                            dir=rating_dir, error="仍有残留文件，保留"))
+                                            dir=rating_dir,
+                                            error=f"仍有残留文件，保留: {sample}"))
                             continue
                         try:
                             shutil.rmtree(rating_path, ignore_errors=True)


### PR DESCRIPTION
## Summary
- remove ignorable OS metadata residue such as .DS_Store, AppleDouble ._* files, Thumbs.db, and desktop.ini before deleting reset rating folders
- preserve real residual files and include sample filenames in the cleanup warning for diagnosis
- add bilingual comments/docstrings around the reset residue handling

## Verification
- .venv/bin/python -m py_compile tools/find_bird_util.py ui/main_window.py
- temp-directory smoke check confirmed metadata residue is removed while real files remain preserved