### PR TITLE
fix(ui): persist main window state

### DIFF
--- a/advanced_config.py
+++ b/advanced_config.py
@@ -9,6 +9,7 @@ import json
 import os
 from pathlib import Path
 import sys
+from typing import Dict, Optional
 from tools.i18n import t as _t
 from config import get_app_config_dir, get_lazy_registry
 
@@ -134,6 +135,12 @@ class AdvancedConfig:
 
         # 最近选鸟目录历史（最多保留 10 个，按最近使用时间倒序）
         "recent_directories": [],
+
+        # 主窗口位置和最大化状态。普通几何与最大化状态分开存储，便于跨屏幕校验。
+        # Main-window placement and maximized state. Normal geometry is stored
+        # separately from maximized state so it can be validated across monitors.
+        "main_window_geometry": None,
+        "main_window_maximized": False,
 
         # V4.3 Phase 1: 视频分析配置 / Video analysis config
         # video_max_frames        : 单视频抽帧总数上限（处理时间与视频时长解耦）
@@ -611,6 +618,64 @@ class AdvancedConfig:
 
     def set_exposure_check(self, value):
         self.config["exposure_check"] = bool(value)
+
+    # ──────────────────────────────────────────────
+    # 主窗口位置状态
+    # ──────────────────────────────────────────────
+    def get_main_window_geometry(self) -> Optional[Dict[str, int]]:
+        """
+        获取主窗口普通状态下的几何信息。
+
+        返回:
+        Optional[Dict[str, int]]: 包含 x/y/width/height 的字典；缺失或格式异常时返回 None。
+
+        Get the main window normal-state geometry.
+
+        Return:
+        Optional[Dict[str, int]]: Dict with x/y/width/height, or None when missing/invalid.
+        """
+        value = self.config.get("main_window_geometry")
+        if not isinstance(value, dict):
+            return None
+
+        required_keys = ("x", "y", "width", "height")
+        if not all(key in value for key in required_keys):
+            return None
+
+        try:
+            return {key: int(value[key]) for key in required_keys}
+        except (TypeError, ValueError):
+            return None
+
+    def set_main_window_geometry(self, value: Optional[Dict[str, int]]) -> None:
+        """
+        保存主窗口普通状态下的几何信息。
+
+        参数:
+        value (Optional[Dict[str, int]]): 包含 x/y/width/height 的字典；None 表示清空。
+
+        Save the main window normal-state geometry.
+
+        Parameters:
+        value (Optional[Dict[str, int]]): Dict with x/y/width/height, or None to clear.
+        """
+        if value is None:
+            self.config["main_window_geometry"] = None
+            return
+
+        self.config["main_window_geometry"] = {
+            "x": int(value["x"]),
+            "y": int(value["y"]),
+            "width": int(value["width"]),
+            "height": int(value["height"]),
+        }
+
+    @property
+    def main_window_maximized(self) -> bool:
+        return bool(self.config.get("main_window_maximized", False))
+
+    def set_main_window_maximized(self, value: bool) -> None:
+        self.config["main_window_maximized"] = bool(value)
 
     # ──────────────────────────────────────────────
     # 最近选鸟目录历史

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -29,7 +29,10 @@ from PySide6.QtWidgets import (
     QDialog,
     QSystemTrayIcon, QApplication  # V4.0: 系统托盘图标
 )
-from PySide6.QtCore import Qt, Signal, QObject, Slot, QTimer, QPropertyAnimation, QEasingCurve, QMimeData, QThread, QStandardPaths, QSize
+from PySide6.QtCore import (
+    Qt, Signal, QObject, Slot, QTimer, QPropertyAnimation, QEasingCurve, QMimeData,
+    QThread, QStandardPaths, QSize, QRect,
+)
 from PySide6.QtGui import QFont, QPixmap, QIcon, QAction, QTextCursor, QColor, QDragEnterEvent, QDropEvent
 
 from tools.i18n import get_i18n, set_primary_language
@@ -709,6 +712,7 @@ class SuperPickyMainWindow(QMainWindow):
         self.worker_signals = None
         self.current_progress = 0
         self.total_files = 0
+        self._main_window_placement_saved = False
 
         # 设置窗口
         self._setup_window()
@@ -806,7 +810,10 @@ class SuperPickyMainWindow(QMainWindow):
         """设置窗口属性"""
         self.setWindowTitle(self.i18n.t("app.window_title"))
         self.setMinimumSize(800, 720)
-        self.resize(960, 820)
+        if not self._restore_main_window_geometry():
+            self.resize(960, 820)
+        if self.config.main_window_maximized:
+            QTimer.singleShot(0, self.showMaximized)
 
         # 应用全局样式表
         self.setStyleSheet(GLOBAL_STYLE)
@@ -815,6 +822,90 @@ class SuperPickyMainWindow(QMainWindow):
         icon_path = get_resource_path("img/icon.png")
         if os.path.exists(icon_path):
             self.setWindowIcon(QIcon(icon_path))
+
+    def _restore_main_window_geometry(self) -> bool:
+        """
+        恢复主窗口普通状态下的几何信息。
+
+        返回:
+        bool: 成功恢复返回 True，否则回退默认窗口大小。
+
+        Restore the main window normal-state geometry.
+
+        Return:
+        bool: True when restored; False when the default size should be used.
+        """
+        saved = self.config.get_main_window_geometry()
+        if not saved:
+            return False
+
+        rect = QRect(saved["x"], saved["y"], saved["width"], saved["height"])
+        if not self._is_valid_main_window_rect(rect):
+            return False
+
+        self.setGeometry(rect)
+        return True
+
+    def _is_valid_main_window_rect(self, rect: QRect) -> bool:
+        """
+        校验保存的窗口矩形是否仍适合当前屏幕环境。
+
+        参数:
+        rect (QRect): 待校验的窗口矩形。
+
+        返回:
+        bool: 矩形尺寸达标且至少与一个可用屏幕相交时返回 True。
+
+        Validate whether a saved window rectangle still fits the current screens.
+
+        Parameters:
+        rect (QRect): Window rectangle to validate.
+
+        Return:
+        bool: True when size is acceptable and it intersects an available screen.
+        """
+        if not rect.isValid() or rect.width() < 800 or rect.height() < 720:
+            return False
+
+        screens = QApplication.screens()
+        if not screens:
+            return True
+
+        return any(screen.availableGeometry().intersects(rect) for screen in screens)
+
+    def _save_main_window_placement(self) -> None:
+        """
+        保存主窗口普通几何和最大化状态。
+
+        最大化状态与普通几何分开保存；这样下次以最大化打开后，取消最大化仍能回到
+        用户上次的普通窗口大小。最小化状态不保存，避免应用下次启动时不可见。
+
+        Save the main window normal geometry and maximized state.
+
+        Maximized state is stored separately from normal geometry so restoring from
+        maximized returns to the user's previous normal size. Minimized state is
+        intentionally ignored so the app never reopens invisible.
+        """
+        if self._main_window_placement_saved:
+            return
+
+        if self.isMaximized() or self.isMinimized():
+            rect = self.normalGeometry()
+        else:
+            rect = self.geometry()
+
+        if self._is_valid_main_window_rect(rect):
+            self.config.set_main_window_geometry(
+                {
+                    "x": rect.x(),
+                    "y": rect.y(),
+                    "width": rect.width(),
+                    "height": rect.height(),
+                }
+            )
+        self.config.set_main_window_maximized(self.isMaximized())
+        if self.config.save():
+            self._main_window_placement_saved = True
 
     def _setup_menu(self):
         """设置菜单栏"""
@@ -1072,6 +1163,7 @@ class SuperPickyMainWindow(QMainWindow):
     
     def _quit_app(self):
         """完全退出应用（清理由 aboutToQuit 信号统一处理）"""
+        self._save_main_window_placement()
         self._really_quit = True
         if hasattr(self, 'tray_icon'):
             self.tray_icon.hide()         # 先隐藏托盘，避免用户二次点击
@@ -1082,6 +1174,8 @@ class SuperPickyMainWindow(QMainWindow):
         无论通过 X按鈕 / Cmd+Q / 托盘退出，都会经过此处。
         Mac 和 Windows 均适用。
         """
+        self._save_main_window_placement()
+
         if self.worker and self.worker.is_alive():
             try:
                 self.worker.request_stop()
@@ -3029,6 +3123,7 @@ class SuperPickyMainWindow(QMainWindow):
         # V4.0: 后台模式不停止服务器
         if getattr(self, '_background_mode', False):
             print("✅ 后台模式：服务器继续运行")
+            self._save_main_window_placement()
             if hasattr(self, 'tray_icon') and self.tray_icon:
                 self.tray_icon.hide()
             event.accept()
@@ -3052,6 +3147,7 @@ class SuperPickyMainWindow(QMainWindow):
             else:
                 event.ignore()
         else:
+            self._save_main_window_placement()
             QApplication.quit()           # 触发 aboutToQuit → _cleanup_on_quit
             event.accept()
 


### PR DESCRIPTION
## Summary
- persist main-window normal geometry and maximized state in advanced_config.json
- restore saved placement on startup with screen validation and default fallback
- save placement directly from close/quit paths so state is captured before Qt teardown

## Verification
- .venv/bin/python -m py_compile advanced_config.py ui/main_window.py
- temp-config smoke test for geometry save/load validation
- manual user test confirmed the amended save path works